### PR TITLE
pulled in signal-exit module

### DIFF
--- a/bin/nyc.js
+++ b/bin/nyc.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-var sw = require('spawn-wrap')
+var foreground = require('foreground-child'),
+  sw = require('spawn-wrap')
 
 if (process.env.NYC_CWD) {
   var NYC = require('../')
@@ -20,18 +21,5 @@ if (process.env.NYC_CWD) {
     NYC_CWD: process.cwd()
   })
 
-  // this spawn gets wrapped
-  var child = require('child_process').spawn(
-    process.argv[2],
-    process.argv.slice(3),
-    { stdio: 'inherit' }
-  )
-
-  child.on('close', function (code, signal) {
-    if (signal) {
-      process.kill(process.pid, signal)
-    } else {
-      process.exit(code)
-    }
-  })
+  foreground(process.argv.slice(2))
 }

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var _ = require('lodash'),
   mkdirp = require('mkdirp'),
   path = require('path'),
   rimraf = require('rimraf'),
+  onExit = require('signal-exit'),
   stripBom = require('strip-bom')
 
 function NYC (opts) {
@@ -64,7 +65,7 @@ NYC.prototype._wrapRequire = function () {
 NYC.prototype._wrapExit = function () {
   var _this = this,
     outputCoverage = function () {
-      var coverage
+      var coverage = global.__coverage__
       if (typeof __coverage__ === 'object') coverage = __coverage__
       if (!coverage) return
 
@@ -75,13 +76,7 @@ NYC.prototype._wrapExit = function () {
       )
     }
 
-  var _kill = process.kill
-  process.kill = function (pid, signal) {
-    outputCoverage()
-    _kill(pid, signal)
-  }
-
-  process.on('exit', function () {
+  onExit(function () {
     outputCoverage()
   })
 }

--- a/package.json
+++ b/package.json
@@ -28,11 +28,13 @@
   "author": "Ben Coe <ben@npmjs.com>",
   "license": "ISC",
   "dependencies": {
+    "foreground-child": "^1.1.0",
     "istanbul": "^0.3.14",
     "jsonstream": "^1.0.3",
     "lodash": "^3.8.0",
     "mkdirp": "^0.5.0",
     "rimraf": "^2.3.3",
+    "signal-exit": "^1.0.1",
     "spawn-wrap": "0.0.9",
     "strip-bom": "^1.0.0",
     "yargs": "^3.8.0"


### PR DESCRIPTION
pulled in the signal-exit module, which ensures that an exit event is fired regardless of whether execution ends normally, via kill, or via exit.