### PR TITLE
ensure that writing code coverage always happens last

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,9 +76,12 @@ NYC.prototype._wrapExit = function () {
       )
     }
 
-  onExit(function () {
-    outputCoverage()
-  })
+    var opts = {alwaysLast: true}
+    // we're running as a unit test.
+    if (process.env.TAP) opts.maxListeners = 2
+    onExit(function () {
+      outputCoverage()
+    }, opts)
 }
 
 NYC.prototype.wrap = function (bin) {

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "lodash": "^3.8.0",
     "mkdirp": "^0.5.0",
     "rimraf": "^2.3.3",
-    "signal-exit": "^1.2.0",
-    "spawn-wrap": "^0.1.1",
+    "signal-exit": "^1.3.0",
+    "spawn-wrap": "^0.1.2",
     "strip-bom": "^1.0.0",
     "yargs": "^3.8.0"
   },


### PR DESCRIPTION
* set the `alwaysLast` option for signal-exit, so that code coverage always happens last.
* upgraded signal-exit/spawn-wrap dependency.