### PR TITLE
Use settings from .istanbul.yml when configuring instrumenter

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,13 @@
 var _ = require('lodash'),
   fs = require('fs'),
   istanbul = require('istanbul'),
-  instrumenter = new istanbul.Instrumenter(),
+  istanbulConfig = istanbul.config.loadFile().instrumentation.config,
+  instrumenter = new istanbul.Instrumenter({
+    coverageVariable: istanbulConfig.variable,
+    embedSource: istanbulConfig['embed-source'],
+    noCompact: !istanbulConfig.compact,
+    preserveComments: istanbulConfig['preserve-comments']
+  }),
   mkdirp = require('mkdirp'),
   path = require('path'),
   rimraf = require('rimraf'),

--- a/index.js
+++ b/index.js
@@ -3,12 +3,12 @@
 var _ = require('lodash'),
   fs = require('fs'),
   istanbul = require('istanbul'),
-  istanbulConfig = istanbul.config.loadFile().instrumentation.config,
+  instrumenterConfig = istanbul.config.loadFile().instrumentation.config,
   instrumenter = new istanbul.Instrumenter({
-    coverageVariable: istanbulConfig.variable,
-    embedSource: istanbulConfig['embed-source'],
-    noCompact: !istanbulConfig.compact,
-    preserveComments: istanbulConfig['preserve-comments']
+    coverageVariable: instrumenterConfig.variable,
+    embedSource: instrumenterConfig['embed-source'],
+    noCompact: !instrumenterConfig.compact,
+    preserveComments: instrumenterConfig['preserve-comments']
   }),
   mkdirp = require('mkdirp'),
   path = require('path'),


### PR DESCRIPTION
I've just tried this out against a test suite that opens 300+ subprocess during the run and it works great, so thanks!

There was an issue with some tests though, specifically tests covering code that uses the [heredoc](https://www.npmjs.com/package/heredoc) package would fail when run wrapped by this module. This is because normally, instrumenting a file results in all comments being stripped from it, and heredoc uses a comment-based workaround to enable multi-line strings.

There is an option that can be provided to the istanbul instrumenter to preserve comments - this changes how the instrumenter is initialised, so its options can be read out of a `.istanbul.yml` [file in the project root](https://github.com/gotwarlost/istanbul#configuring) and passed in.

The other three passed in options I don't actually need, but they [match how the instrumenter is initialised by istanbul's own CLI command](https://github.com/gotwarlost/istanbul/blob/master/lib/command/instrument.js#L215).

Provided you're OK with the change, guidance on how to test this would be appreciated - I'd normally move the `new istanbul.Instrumenter` into the `NYC` constructor, then bring in `sinon` to stub the return value of loadFile and assert `new istanbul.Instrumenter` was called with it, but it looks like that may not be inline with this project's style?