### PR TITLE
upgrade signal-exit

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,6 @@ NYC.prototype._wrapExit = function () {
 
     var opts = {alwaysLast: true}
     // allow more signal handlers in unit tests.
-    if (process.env.NYC_TEST) opts.maxListeners = 2
     onExit(function () {
       outputCoverage()
     }, opts)

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lodash": "^3.8.0",
     "mkdirp": "^0.5.0",
     "rimraf": "^2.3.3",
-    "signal-exit": "^1.3.0",
+    "signal-exit": "^2.0.0",
     "spawn-wrap": "^0.1.2",
     "strip-bom": "^1.0.0",
     "yargs": "^3.8.0"


### PR DESCRIPTION
upgrade of signal-exit, see:

https://github.com/bcoe/signal-exit/pull/9

we now better handle multiple listeners on a single signal.