### PR TITLE
load in instrumenter configuration from .istanbul.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,17 @@ adding the following configuration:
 }}
 ```
 
+## Configuring Istanbul
+
+Behind the scenes nyc uses [istanbul](https://www.npmjs.com/package/istanbul). You
+can place a `.istanbul.yml` file in your project's root directory to pass config
+setings to istanbul's code instrumenter:
+
+```yml
+instrumentation:
+  preserve-comments: true
+```
+
 ## Integrating With Coveralls
 
 [coveralls.io](https://coveralls.io) is a great tool for adding

--- a/index.js
+++ b/index.js
@@ -2,14 +2,6 @@
 
 var _ = require('lodash'),
   fs = require('fs'),
-  istanbul = require('istanbul'),
-  instrumenterConfig = istanbul.config.loadFile().instrumentation.config,
-  instrumenter = new istanbul.Instrumenter({
-    coverageVariable: instrumenterConfig.variable,
-    embedSource: instrumenterConfig['embed-source'],
-    noCompact: !instrumenterConfig.compact,
-    preserveComments: instrumenterConfig['preserve-comments']
-  }),
   mkdirp = require('mkdirp'),
   path = require('path'),
   rimraf = require('rimraf'),
@@ -24,7 +16,8 @@ function NYC (opts) {
     ),
     tempDirectory: './nyc_output',
     cwd: process.env.NYC_CWD || process.cwd(),
-    reporter: 'text'
+    reporter: 'text',
+    istanbul: require('istanbul')
   }, opts)
 
   var config = require(path.resolve(this.cwd, './package.json')).config || {}
@@ -36,7 +29,24 @@ function NYC (opts) {
     return new RegExp(p)
   })
 
+  this.instrumenter = this._createInstrumenter()
+
   mkdirp.sync(this.tmpDirectory())
+}
+
+NYC.prototype._createInstrumenter = function () {
+  var configFile = path.resolve(this.cwd, './.istanbul.yml')
+
+  if (!fs.existsSync(configFile)) configFile = undefined
+
+  var instrumenterConfig = this.istanbul.config.loadFile(configFile).instrumentation.config
+
+  return new this.istanbul.Instrumenter({
+    coverageVariable: '__coverage__',
+    embedSource: instrumenterConfig['embed-source'],
+    noCompact: !instrumenterConfig.compact,
+    preserveComments: instrumenterConfig['preserve-comments']
+  })
 }
 
 NYC.prototype.cleanup = function () {
@@ -58,7 +68,7 @@ NYC.prototype._wrapRequire = function () {
     }
 
     if (instrument) {
-      content = instrumenter.instrumentSync(
+      content = _this.instrumenter.instrumentSync(
         content,
         './' + relFile
       )
@@ -96,8 +106,8 @@ NYC.prototype.wrap = function (bin) {
 }
 
 NYC.prototype.report = function (_collector, _reporter) {
-  var collector = _collector || new istanbul.Collector(),
-    reporter = _reporter || new istanbul.Reporter()
+  var collector = _collector || new this.istanbul.Collector(),
+    reporter = _reporter || new this.istanbul.Reporter()
 
   this._loadReports().forEach(function (report) {
     collector.add(report)

--- a/index.js
+++ b/index.js
@@ -3,7 +3,13 @@
 var _ = require('lodash'),
   fs = require('fs'),
   istanbul = require('istanbul'),
-  instrumenter = new istanbul.Instrumenter(),
+  istanbulConfig = istanbul.config.loadFile().instrumentation.config,
+  instrumenter = new istanbul.Instrumenter({
+    coverageVariable: istanbulConfig.variable,
+    embedSource: istanbulConfig['embed-source'],
+    noCompact: !istanbulConfig.compact,
+    preserveComments: istanbulConfig['preserve-comments']
+  }),
   mkdirp = require('mkdirp'),
   path = require('path'),
   rimraf = require('rimraf'),

--- a/index.js
+++ b/index.js
@@ -3,12 +3,12 @@
 var _ = require('lodash'),
   fs = require('fs'),
   istanbul = require('istanbul'),
-  istanbulConfig = istanbul.config.loadFile().instrumentation.config,
+  instrumenterConfig = istanbul.config.loadFile().instrumentation.config,
   instrumenter = new istanbul.Instrumenter({
-    coverageVariable: istanbulConfig.variable,
-    embedSource: istanbulConfig['embed-source'],
-    noCompact: !istanbulConfig.compact,
-    preserveComments: istanbulConfig['preserve-comments']
+    coverageVariable: instrumenterConfig.variable,
+    embedSource: instrumenterConfig['embed-source'],
+    noCompact: !instrumenterConfig.compact,
+    preserveComments: instrumenterConfig['preserve-comments']
   }),
   mkdirp = require('mkdirp'),
   path = require('path'),

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "chai": "^2.3.0",
     "coveralls": "^2.11.2",
+    "sinon": "^1.14.1",
     "standard": "^3.7.3",
     "tap": "1.0.4"
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "reporter"
   ],
   "contributors": [
-    "Isaac Schlueter <i@izs.me>"
+    {"name": "Isaac Schlueter", "website": "https://github.com/isaacs"},
+    {"name": "Ollie Buck", "website": "https://github.com/shackpank"}
   ],
   "author": "Ben Coe <ben@npmjs.com>",
   "license": "ISC",

--- a/test/fixtures/.istanbul.yml
+++ b/test/fixtures/.istanbul.yml
@@ -1,0 +1,2 @@
+instrumentation:
+  preserve-comments: true


### PR DESCRIPTION
Thanks for the awesome work @shackpank. I added a few tests, but otherwise things seemed to work great. a couple notes:

* Since `nyc` relies on the global coverage variable being `__coverage__` I've made this value hardcoded (in subprocesses I've seen some issues surrounding accessing `process.globals`, so I think it's good to push people towards `__coverage__`).
* I use the `this.cwd` directory variable, so that we'll keep loading the appropriate `.istanbul.yml` as `cwd` is changed in tests.
* I've added you as an owner to the GitHub project, I'm excited for any future contributions you might be able to make.
