### PR TITLE
new signal-exit handles process.exit() in process.on('exit')

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ NYC.prototype._wrapExit = function () {
   // regardless of how the process exits.
   onExit(function () {
     outputCoverage()
-  })
+  }, {alwaysLast: true})
 }
 
 NYC.prototype.wrap = function (bin) {

--- a/index.js
+++ b/index.js
@@ -92,11 +92,11 @@ NYC.prototype._wrapExit = function () {
       )
     }
 
-  var opts = {alwaysLast: true}
-  // allow more signal handlers in unit tests.
+  // we always want to write coverage
+  // regardless of how the process exits.
   onExit(function () {
     outputCoverage()
-  }, opts)
+  })
 }
 
 NYC.prototype.wrap = function (bin) {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lodash": "^3.8.0",
     "mkdirp": "^0.5.0",
     "rimraf": "^2.3.3",
-    "signal-exit": "^2.0.0",
+    "signal-exit": "^2.1.0",
     "spawn-wrap": "^1.0.1",
     "strip-bom": "^1.0.0",
     "yargs": "^3.8.0"


### PR DESCRIPTION
upgrades signal-exit to version that better handles:

```js
process.on('exit', function () {
  process.exit(5);
})
```

CC: @isaacs 