### PR TITLE
slight tweaks based on @sindresorhus' feedback: see #20 #21

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-nyc_output
+.nyc_output
 coverage
 node_modules

--- a/README.md
+++ b/README.md
@@ -119,5 +119,5 @@ after_success: npm run coverage
 
 That's all there is to it!
 
-_Note: by default coveralls.io adds comments to pull-request on GitHub, this can
+_Note: by default coveralls.io adds comments to pull-requests on GitHub, this can
 feel intrusive. To disable this, click on your repo on coveralls.io and uncheck `LEAVE COMMENTS?`._

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ that works well for applications that spawn subprocesses.
 ## Instrumenting Your Code
 
 Simply run your tests with `nyc`, and it will collect coverage information for
-each process and store it in `nyc_output`:
+each process and store it in `.nyc_output`:
 
 ```shell
 nyc npm test
@@ -118,3 +118,6 @@ after_success: npm run coverage
 ```
 
 That's all there is to it!
+
+_Note: by default coveralls.io adds comments to pull-request on GitHub, this can
+feel intrusive. To disable this, click on your repo on coveralls.io and uncheck `LEAVE COMMENTS?`.

--- a/README.md
+++ b/README.md
@@ -120,4 +120,4 @@ after_success: npm run coverage
 That's all there is to it!
 
 _Note: by default coveralls.io adds comments to pull-request on GitHub, this can
-feel intrusive. To disable this, click on your repo on coveralls.io and uncheck `LEAVE COMMENTS?`.
+feel intrusive. To disable this, click on your repo on coveralls.io and uncheck `LEAVE COMMENTS?`._

--- a/bin/nyc.js
+++ b/bin/nyc.js
@@ -16,7 +16,7 @@ if (process.env.NYC_CWD) {
   var NYC = require('../'),
     yargs = require('yargs')
       .usage('$0 [command] [options]\n\nrun with a file as the first argument, to instrument it with coverage')
-      .command('report', 'run coverage report on nyc_output', function (yargs) {
+      .command('report', 'run coverage report for .nyc_output', function (yargs) {
         yargs
           .option('r', {
             alias: 'reporter',

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function NYC (opts) {
       __dirname,
       './bin/nyc.js'
     ),
-    tempDirectory: './nyc_output',
+    tempDirectory: './.nyc_output',
     cwd: process.env.NYC_CWD || process.cwd(),
     reporter: 'text',
     istanbul: require('istanbul')

--- a/test/nyc-test.js
+++ b/test/nyc-test.js
@@ -138,7 +138,7 @@ describe('nyc', function () {
           stdio: 'inherit'
         })
 
-      fs.writeFileSync('./nyc_output/bad.json', '}', 'utf-8')
+      fs.writeFileSync('./.nyc_output/bad.json', '}', 'utf-8')
 
       proc.on('close', function () {
         nyc.report(


### PR DESCRIPTION
slight tweaks based on @sindresorhus' feedback: see #20 #21

* switches `nyc_output` to `.nyc_output`.
* adds note about disabling pull request comments in coveralls.