### PR TITLE
Remove unused jsonstream dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "dependencies": {
     "foreground-child": "^1.2.0",
     "istanbul": "^0.3.14",
-    "jsonstream": "^1.0.3",
     "lodash": "^3.8.0",
     "mkdirp": "^0.5.0",
     "rimraf": "^2.3.3",


### PR DESCRIPTION
I was going to rename it to JSONStream but it turns out that it's not being used.

Because of https://github.com/dominictarr/JSONStream/issues/68, it's causing lots of `npm ERR! missing: JSONStream@^1.0.3` and `npm ERR! extraneous: jsonstream@1.0.3 ` when your dependencies depend on both in case-insensitive OSes (e.g. browserify and tap).