### PR TITLE
add reporter array support

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,7 +113,13 @@ NYC.prototype.report = function (_collector, _reporter) {
     collector.add(report)
   })
 
-  reporter.add(this.reporter)
+  if (Array.isArray(this.reporter)) {
+    this.reporter.forEach(function (_reporter) {
+      reporter.add(_reporter)
+    })
+  } else {
+    reporter.add(this.reporter)
+  }
 
   reporter.write(collector, true, function () {})
 }

--- a/test/nyc-test.js
+++ b/test/nyc-test.js
@@ -155,6 +155,37 @@ describe('nyc', function () {
         )
       })
     })
+
+    it('handles multiple reporters', function (done) {
+      var reporters = ['text-summary', 'text-lcov'],
+      incr = 0,
+      nyc = new NYC({
+        cwd: process.cwd(),
+        reporter: reporters
+      }),
+      proc = spawn(process.execPath, ['./test/fixtures/sigint.js'], {
+        cwd: process.cwd(),
+        env: process.env,
+        stdio: 'inherit'
+      })
+
+      proc.on('close', function () {
+        nyc.report(
+          {
+            add: function (report) {}
+          },
+          {
+            add: function (reporter) {
+              incr += !!~reporters.indexOf(reporter)
+            },
+            write: function () {
+              incr.should.eql(reporters.length)
+              return done()
+            }
+          }
+        )
+      })
+    })
   })
 
   describe('.istanbul.yml configuration', function () {


### PR DESCRIPTION
I've added the ability to define multiple reporters at once.

Example usage from the cli:

`nyc report --reporter=html --reporter=text`

**edit**: this is just a minor convenience (over simply running the command twice), but figured it was worth a shot. ¯\\_(ツ)_/¯