### PR TITLE
upgrade tap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 sudo: false
 language: node_js
 node_js:
-- '0.12'
-- '0.10'
-- iojs
+  - '0.12'
+  - '0.10'
+  - iojs
 env:
 - secure: "SVg7NpV0Sru296kdp+eFl07RFjtJy242fWQ1KDCUdk/1EtZEOzBoSKP7Tn3zX/VLBieexL0T31EwYvRztnL97Sr8VgpYU0z95vCPO8FrixElJR6NH3dqrKeNzC3xOYdV0fy2b4UMlPJOI0aYDT1KHm1aWtkb2J8zqII+XbMtlDaelfHCDxa2+RBII9nYYDP62z+0chQFS6MGPSNwve3G2emYHZpYP5iTFmOzaFUCAjLskKvnnsY0jyx5XssqAo17747WKZl5SDgN8YHZIwhE5tB9m9j3MGjJhwdsR3kmq2om0GD1tQFFAXzWhWad3zNBUE4fLqswgASi39o5NIEzvSRzpw77ttOkkIFGem0l421Zi25W8x5n6GZvP06Y47ddmjNBlniwIzG4fb3dbIByCy/g5SjUYmfnke7stXXBKsPv0eEadlLGFWnG5RIfnyGjvUgQ//QXSAnBBzYF9IK+KUdU8c9kHF6kPybsGEzjQoX+4EJL6kZ4sNX9qxjHERUr4Jb6rAMOnKI9VtCBNqwcCC3nV5DDWHS86hKwbuTbBFkszP7majOi0kUQJTO/tZGwVVcphSDwhL5QkmMepLOqXyRICdUcB2ffXHYhZLiZPofYdom8csaDolqFkotJEBj3GM3gwHvUC3i1vxshxtjF6NHjanhpiIpHLRCs6R1RESE="
-after_success: npm run coverage

--- a/bin/nyc.js
+++ b/bin/nyc.js
@@ -20,8 +20,9 @@ if (process.env.NYC_CWD) {
         yargs
           .option('r', {
             alias: 'reporter',
-            describe: 'coverage reporter to use',
-            default: 'text'
+            describe: 'coverage reporter(s) to use',
+            default: 'text',
+            array: true
           })
           .help('h')
           .example('$0 report --reporter=lcov', 'output an HTML lcov report to ./coverage')

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ function NYC (opts) {
     ),
     tempDirectory: './.nyc_output',
     cwd: process.env.NYC_CWD || process.cwd(),
-    reporter: 'text',
+    reporter: ['text'],
     istanbul: require('istanbul')
   }, opts)
 
@@ -113,13 +113,9 @@ NYC.prototype.report = function (_collector, _reporter) {
     collector.add(report)
   })
 
-  if (Array.isArray(this.reporter)) {
-    this.reporter.forEach(function (_reporter) {
-      reporter.add(_reporter)
-    })
-  } else {
-    reporter.add(this.reporter)
-  }
+  this.reporter.forEach(function (_reporter) {
+    reporter.add(_reporter)
+  })
 
   reporter.write(collector, true, function () {})
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
   },
   "devDependencies": {
     "chai": "^3.0.0",
-    "coveralls": "^2.11.2",
     "sinon": "^1.14.1",
     "standard": "^4.0.1",
     "tap": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "a code coverage tool that works well with subprocesses.",
   "main": "index.js",
   "scripts": {
-    "test": "standard && ./bin/nyc.js tap ./test/nyc-test.js",
-    "coverage": "./bin/nyc.js report --reporter=text-lcov | coveralls"
+    "test": "standard && tap --coverage ./test/nyc-test.js"
   },
   "bin": {
     "nyc": "./bin/nyc.js"
@@ -47,11 +46,11 @@
     "yargs": "^3.8.0"
   },
   "devDependencies": {
-    "chai": "^2.3.0",
+    "chai": "^3.0.0",
     "coveralls": "^2.11.2",
     "sinon": "^1.14.1",
-    "standard": "^3.7.3",
-    "tap": "1.0.4"
+    "standard": "^4.0.1",
+    "tap": "^1.2.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
* upgrade tap, which now has nyc coverage reporting/coveralls built right in.
* remove now unused coveralls dependency.
* switch reporter(s) to using the yargs `array` variable type.