### PR TITLE
combine instrumentation and reporting step (it's what plants crave).

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,16 @@ that works for applications that spawn subprocesses.
 ## Instrumenting Your Code
 
 Simply run your tests with `nyc`, and it will collect coverage information for
-each process and store it in `.nyc_output`:
+each process and store it in `.nyc_output`.
 
 ```shell
 nyc npm test
+```
+
+you can pass a list of Istanbul reporters that you'd like to run:
+
+```shell
+nyc --reporter=lcov --reporter=text-lcov npm test
 ```
 
 If you're so inclined, you can simply add nyc to the test stanza in your package.json:

--- a/bin/nyc.js
+++ b/bin/nyc.js
@@ -74,9 +74,7 @@ if (process.env.NYC_CWD) {
     // run a report.
     process.env.NYC_CWD = process.cwd()
 
-    ;(new NYC({
-      reporter: argv.reporter
-    })).report()
+    report(argv)
   } else if (~argv._.indexOf('check-coverage')) {
     foreground(
       path.resolve(__dirname, '../node_modules/.bin/istanbul'),

--- a/bin/nyc.js
+++ b/bin/nyc.js
@@ -80,15 +80,27 @@ if (process.env.NYC_CWD) {
     )
   } else if (argv._.length) {
     // wrap subprocesses and execute argv[1]
-    ;(new NYC()).cleanup()
+    var nyc = (new NYC())
+    nyc.cleanup()
 
     sw([__filename], {
       NYC_CWD: process.cwd()
     })
 
-    foreground(process.argv.slice(2))
+    foreground(nyc.mungeArgs(argv), function (done) {
+      if (argv['output-report']) report(argv)
+      return done()
+    })
   } else {
     // I don't have a clue what you're doing.
     yargs.showHelp()
   }
+}
+
+function report (argv) {
+  process.env.NYC_CWD = process.cwd()
+
+  ;(new NYC({
+    reporter: argv.reporter
+  })).report()
 }

--- a/bin/nyc.js
+++ b/bin/nyc.js
@@ -23,8 +23,7 @@ if (process.env.NYC_CWD) {
         .option('r', {
           alias: 'reporter',
           describe: 'coverage reporter(s) to use',
-          default: 'text',
-          array: true
+          default: 'text'
         })
         .help('h')
         .alias('h', 'help')
@@ -51,6 +50,17 @@ if (process.env.NYC_CWD) {
         .help('h')
         .alias('h', 'help')
         .example('$0 check-coverage --lines 95', "check whether the JSON in nyc's output folder meets the thresholds provided")
+    })
+    .option('r', {
+      alias: 'reporter',
+      describe: 'coverage reporter(s) to use',
+      default: 'text'
+    })
+    .option('s', {
+      alias: 'silent',
+      default: false,
+      type: 'boolean',
+      describe: "don't output a report after tests finish running"
     })
     .help('h')
     .alias('h', 'help')
@@ -88,7 +98,7 @@ if (process.env.NYC_CWD) {
     })
 
     foreground(nyc.mungeArgs(argv), function (done) {
-      if (argv['output-report']) report(argv)
+      if (!argv.silent) report(argv)
       return done()
     })
   } else {

--- a/index.js
+++ b/index.js
@@ -15,9 +15,11 @@ function NYC (opts) {
     ),
     tempDirectory: './.nyc_output',
     cwd: process.env.NYC_CWD || process.cwd(),
-    reporter: ['text'],
+    reporter: 'text',
     istanbul: require('istanbul')
   }, opts)
+
+  if (!Array.isArray(this.reporter)) this.reporter = [this.reporter]
 
   var config = require(path.resolve(this.cwd, './package.json')).config || {}
   config = config.nyc || {}
@@ -105,6 +107,8 @@ NYC.prototype.wrap = function (bin) {
 }
 
 NYC.prototype.report = function (_collector, _reporter) {
+  cb = cb || function () {}
+
   var collector = _collector || new this.istanbul.Collector()
   var reporter = _reporter || new this.istanbul.Reporter()
 
@@ -116,7 +120,7 @@ NYC.prototype.report = function (_collector, _reporter) {
     reporter.add(_reporter)
   })
 
-  reporter.write(collector, true, function () {})
+  reporter.write(collector, true, cb)
 }
 
 NYC.prototype._loadReports = function () {
@@ -137,6 +141,12 @@ NYC.prototype._loadReports = function () {
 
 NYC.prototype.tmpDirectory = function () {
   return path.resolve(this.cwd, './', this.tempDirectory)
+}
+
+NYC.prototype.mungeArgs = function (yargv) {
+  return process.argv.slice(
+    process.argv.indexOf(yargv._[0])
+  )
 }
 
 module.exports = NYC

--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@ NYC.prototype.wrap = function (bin) {
   return this
 }
 
-NYC.prototype.report = function (_collector, _reporter) {
+NYC.prototype.report = function (cb, _collector, _reporter) {
   cb = cb || function () {}
 
   var collector = _collector || new this.istanbul.Collector()
@@ -144,9 +144,9 @@ NYC.prototype.tmpDirectory = function () {
 }
 
 NYC.prototype.mungeArgs = function (yargv) {
-  return process.argv.slice(
-    process.argv.indexOf(yargv._[0])
-  )
+  var argv = process.argv.slice(1)
+
+  return argv.slice(argv.indexOf(yargv._[0]))
 }
 
 module.exports = NYC

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "signal-exit": "^2.1.1",
     "spawn-wrap": "^1.0.1",
     "strip-bom": "^1.0.0",
-    "yargs": "^3.12.0"
+    "yargs": "^3.13.0"
   },
   "devDependencies": {
     "chai": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "author": "Ben Coe <ben@npmjs.com>",
   "license": "ISC",
   "dependencies": {
-    "foreground-child": "^1.2.0",
+    "foreground-child": "^1.3.0",
     "istanbul": "^0.3.16",
     "lodash": "^3.8.0",
     "mkdirp": "^0.5.0",

--- a/test/nyc-test.js
+++ b/test/nyc-test.js
@@ -105,6 +105,7 @@ describe('nyc', function () {
 
       proc.on('close', function () {
         nyc.report(
+          null,
           {
             add: function (report) {
               // the subprocess we ran should output reports
@@ -142,6 +143,7 @@ describe('nyc', function () {
 
       proc.on('close', function () {
         nyc.report(
+          null,
           {
             add: function (report) {}
           },
@@ -171,6 +173,7 @@ describe('nyc', function () {
 
       proc.on('close', function () {
         nyc.report(
+          null,
           {
             add: function (report) {}
           },
@@ -247,6 +250,24 @@ describe('nyc', function () {
 
       afterEach()
       return done()
+    })
+  })
+
+  describe('mungeArgs', function () {
+    it('removes dashed options that proceed bin', function () {
+      process.argv = ['/Users/benjamincoe/bin/iojs',
+        '/Users/benjamincoe/bin/nyc.js',
+        '--reporter',
+        'lcov',
+        'node',
+        'test/nyc-test.js'
+      ]
+
+      var yargv = require('yargs').argv
+
+      var munged = (new NYC()).mungeArgs(yargv)
+
+      munged.should.eql(['node', 'test/nyc-test.js'])
     })
   })
 })

--- a/test/nyc-test.js
+++ b/test/nyc-test.js
@@ -151,6 +151,7 @@ describe('nyc', function () {
             add: function (reporter) {},
             write: function () {
               // we should get here without exception.
+              fs.unlinkSync('./.nyc_output/bad.json')
               return done()
             }
           }


### PR DESCRIPTION
Based on @Raynos' feature request (see #29) I've combined the instrumentation and reporting steps.

I think it would be slick to show a `text` report by default, which makes this a major version bump.

@Raynos @isaacs could you give this branch a spin, the code is somewhat clever for slicing `process.argv` so I'd like to get an extra set of eyes on it.