### PR TITLE
add statements checking to code-coverage

### DIFF
--- a/bin/nyc.js
+++ b/bin/nyc.js
@@ -83,6 +83,7 @@ if (process.env.NYC_CWD) {
         '--lines=' + argv.lines,
         '--functions=' + argv.functions,
         '--branches=' + argv.branches,
+        '--statements=' + argv.statements,
         path.resolve(process.cwd(), './.nyc_output/*.json')
       ]
     )


### PR DESCRIPTION
Looks like you're missing the [`statements` option in Istanbul](https://github.com/gotwarlost/istanbul/blob/f556b46aef4963820c9239fd217f6f08ace275b7/lib/command/check-coverage.js#L62-L65).