### PR TITLE
spawn istanbul in such a way that works for npm@3.x

### DIFF
--- a/bin/nyc.js
+++ b/bin/nyc.js
@@ -81,24 +81,15 @@ if (process.env.NYC_CWD) {
 
     report(argv)
   } else if (~argv._.indexOf('check-coverage')) {
-    var nycOutputDir = path.resolve(process.cwd(), './.nyc_output/*.json')
-
-    // switch the working directory to nyc,
-    // so that we have the standard bin.
-    process.chdir(path.resolve(__dirname, '../'))
-
     foreground(
-      'npm',
+      require.resolve('istanbul/lib/cli'),
       [
-        'run',
-        'istanbul',
-        '--',
         'check-coverage',
         '--lines=' + argv.lines,
         '--functions=' + argv.functions,
         '--branches=' + argv.branches,
         '--statements=' + argv.statements,
-        nycOutputDir
+        path.resolve(process.cwd(), './.nyc_output/*.json')
       ]
     )
   } else if (argv._.length) {

--- a/bin/nyc.js
+++ b/bin/nyc.js
@@ -47,6 +47,11 @@ if (process.env.NYC_CWD) {
           default: 90,
           description: 'what % of lines must be covered?'
         })
+        .option('s', {
+          alias: 'statements',
+          default: 0,
+          description: 'what % of statements must be covered?'
+        })
         .help('h')
         .alias('h', 'help')
         .example('$0 check-coverage --lines 95', "check whether the JSON in nyc's output folder meets the thresholds provided")
@@ -77,8 +82,11 @@ if (process.env.NYC_CWD) {
     report(argv)
   } else if (~argv._.indexOf('check-coverage')) {
     foreground(
-      path.resolve(__dirname, '../node_modules/.bin/istanbul'),
+      'npm',
       [
+        'run',
+        'istanbul',
+        '--',
         'check-coverage',
         '--lines=' + argv.lines,
         '--functions=' + argv.functions,

--- a/bin/nyc.js
+++ b/bin/nyc.js
@@ -81,6 +81,12 @@ if (process.env.NYC_CWD) {
 
     report(argv)
   } else if (~argv._.indexOf('check-coverage')) {
+    var nycOutputDir = path.resolve(process.cwd(), './.nyc_output/*.json')
+
+    // switch the working directory to nyc,
+    // so that we have the standard bin.
+    process.chdir(path.resolve(__dirname, '../'))
+
     foreground(
       'npm',
       [
@@ -92,7 +98,7 @@ if (process.env.NYC_CWD) {
         '--functions=' + argv.functions,
         '--branches=' + argv.branches,
         '--statements=' + argv.statements,
-        path.resolve(process.cwd(), './.nyc_output/*.json')
+        nycOutputDir
       ]
     )
   } else if (argv._.length) {

--- a/bin/nyc.js
+++ b/bin/nyc.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 var foreground = require('foreground-child')
+var NYC = require('../')
 var path = require('path')
 var sw = require('spawn-wrap')
 
 if (process.env.NYC_CWD) {
-  var NYC = require('../')
   ;(new NYC()).wrap()
 
   // make sure we can run coverage on
@@ -14,7 +14,6 @@ if (process.env.NYC_CWD) {
 
   sw.runMain()
 } else {
-  var NYC = require('../')
   var yargs = require('yargs')
     .usage('$0 [command] [options]\n\nrun your tests with the nyc bin to instrument them with coverage')
     .command('report', 'run coverage report for .nyc_output', function (yargs) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "a code coverage tool that works well with subprocesses.",
   "main": "index.js",
   "scripts": {
-    "test": "standard && tap --coverage ./test/nyc-test.js"
+    "test": "standard && tap --coverage ./test/nyc-test.js",
+    "istanbul": "istanbul"
   },
   "bin": {
     "nyc": "./bin/nyc.js"
@@ -37,18 +38,18 @@
   "dependencies": {
     "foreground-child": "^1.3.0",
     "istanbul": "^0.3.16",
-    "lodash": "^3.8.0",
+    "lodash": "^3.10.0",
     "mkdirp": "^0.5.0",
-    "rimraf": "^2.4.0",
+    "rimraf": "^2.4.1",
     "signal-exit": "^2.1.1",
     "spawn-wrap": "^1.0.1",
-    "strip-bom": "^1.0.0",
-    "yargs": "^3.13.0"
+    "strip-bom": "^2.0.0",
+    "yargs": "^3.15.0"
   },
   "devDependencies": {
     "chai": "^3.0.0",
     "sinon": "^1.15.3",
-    "standard": "^4.3.2",
+    "standard": "^4.5.2",
     "tap": "^1.3.0"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "a code coverage tool that works well with subprocesses.",
   "main": "index.js",
   "scripts": {
-    "test": "standard && tap --coverage ./test/nyc-test.js",
-    "istanbul": "istanbul"
+    "istanbul": "istanbul",
+    "test": "standard && tap --coverage ./test/nyc-test.js"
   },
   "bin": {
     "nyc": "./bin/nyc.js"
@@ -19,9 +19,9 @@
   },
   "keywords": [
     "coverage",
+    "reporter",
     "subprocess",
-    "testing",
-    "reporter"
+    "testing"
   ],
   "contributors": [
     {
@@ -40,7 +40,7 @@
     "istanbul": "^0.3.16",
     "lodash": "^3.10.0",
     "mkdirp": "^0.5.0",
-    "rimraf": "^2.4.1",
+    "rimraf": "^2.4.2",
     "signal-exit": "^2.1.1",
     "spawn-wrap": "^1.0.1",
     "strip-bom": "^2.0.0",
@@ -49,7 +49,7 @@
   "devDependencies": {
     "chai": "^3.0.0",
     "sinon": "^1.15.3",
-    "standard": "^4.5.2",
+    "standard": "^4.5.4",
     "tap": "^1.3.0"
   },
   "repository": {


### PR DESCRIPTION
@rmg pointed out in this pull request #30 that istanbul was being invoked in a manner that would work poorly if istanbul got hoisted up into a higher folder.

I've switched to using an approach which @othiym23 and @iarna suggested today:

1. I aded istanbul to npm run scripts.
2. I muck with the `cwd`, so that I can invoke the npm run script from the context of nyc.
3. I invoke the npm run script.

@jasisk I also added the `statements` option in this pull we didn't actually collide on the `s` key, because `s` was used on the outer `yargs` chain, not the inner `yargs` chain.

Let me know what ya'll think.