### PR TITLE
Fix windows spawn

### DIFF
--- a/bin/nyc.js
+++ b/bin/nyc.js
@@ -81,8 +81,9 @@ if (process.env.NYC_CWD) {
     report(argv)
   } else if (~argv._.indexOf('check-coverage')) {
     foreground(
-      require.resolve('istanbul/lib/cli'),
+      process.execPath,
       [
+        require.resolve('istanbul/lib/cli'),
         'check-coverage',
         '--lines=' + argv.lines,
         '--functions=' + argv.functions,

--- a/index.js
+++ b/index.js
@@ -145,8 +145,17 @@ NYC.prototype.tmpDirectory = function () {
 
 NYC.prototype.mungeArgs = function (yargv) {
   var argv = process.argv.slice(1)
+  argv = argv.slice(argv.indexOf(yargv._[0]))
+  if (!/^(node|iojs)$/.test(argv[0]) &&
+      process.platform === 'win32' &&
+      (/\.js$/.test(argv[0]) ||
+        (!/\.(cmd|exe)$/.test(argv[0]) &&
+        !fs.existsSync(argv[0] + '.cmd') &&
+        !fs.existsSync(argv[0] + '.exe')))) {
+    argv.unshift(process.execPath)
+  }
 
-  return argv.slice(argv.indexOf(yargv._[0]))
+  return argv
 }
 
 module.exports = NYC

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "config": {
     "nyc": {
       "exclude": [
-        "node_modules/"
+        "node_modules"
       ]
     }
   },

--- a/test/nyc-test.js
+++ b/test/nyc-test.js
@@ -33,7 +33,7 @@ describe('nyc', function () {
 
       var nyc = new NYC()
 
-      nyc.cwd.should.match(/nyc\/test\/fixtures/)
+      nyc.cwd.should.equal(path.resolve(__dirname, './fixtures'))
       afterEach()
     })
   })
@@ -241,7 +241,7 @@ describe('nyc', function () {
       })
       nyc.wrap()
 
-      istanbul.config.loadFile.calledWithMatch('test/fixtures/.istanbul.yml').should.equal(true)
+      istanbul.config.loadFile.calledWithMatch(path.join('test', 'fixtures', '.istanbul.yml')).should.equal(true)
       istanbul.Instrumenter.calledWith({
         coverageVariable: '__coverage__',
         embedSource: false,


### PR DESCRIPTION
This doesn't fix the problem of coverage not working on Windows, and it isn't a complete fix to the general problem of running on Windows, but if tap is upgraded to a version of nyc with this fix applied it should at least stop crashing on Windows when `tap --coverage` is run.

It may even fix #26 

/cc @sam-github @isaacs 