### PR TITLE
Updated some out of date dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://travis-ci.org/bcoe/nyc.png)](https://travis-ci.org/bcoe/nyc)
 [![Coverage Status](https://coveralls.io/repos/bcoe/nyc/badge.svg?branch=)](https://coveralls.io/r/bcoe/nyc?branch=)
 [![NPM version](https://img.shields.io/npm/v/nyc.svg)](https://www.npmjs.com/package/nyc)
+[![bitHound Score](https://www.bithound.io/github/bcoe/nyc/badges/score.svg)](https://www.bithound.io/github/bcoe/nyc)
 
 ```shell
 nyc npm test

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "license": "ISC",
   "dependencies": {
     "foreground-child": "^1.3.0",
-    "istanbul": "^0.3.16",
+    "istanbul": "^0.3.19",
     "lodash": "^3.10.0",
     "mkdirp": "^0.5.0",
     "rimraf": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "chai": "^3.0.0",
     "sinon": "^1.15.3",
-    "standard": "^4.5.4",
+    "standard": "^5.1.1",
     "tap": "^1.3.0"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "chai": "^3.0.0",
     "sinon": "^1.15.3",
     "standard": "^5.1.1",
-    "tap": "^1.3.0"
+    "tap": "^1.3.4"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
We’ve discovered several insecure (and outdated) NPM modules in this project. You can see the justification for this PR here: https://www.bithound.io/github/bcoe/nyc

To see the updated score you can visit https://www.bithound.io/github/gtanner/nyc.

Updated the following outdated NPM modules

standard
tap
istanbul

notes:

- [x] All test pass
- [x] Added bitHound score badge

In regards to your insecure modules, I am in the process of opening up PR's on them to update dependencies (see https://github.com/gotwarlost/istanbul/pull/431 for an example).
