### PR TITLE
Exclusion improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "glob": "^5.0.14",
     "istanbul": "^0.3.19",
     "lodash": "^3.10.0",
+    "minimatch": "^3.0.0",
     "mkdirp": "^0.5.0",
     "rimraf": "^2.4.2",
     "signal-exit": "^2.1.1",

--- a/test/fixtures/package.json
+++ b/test/fixtures/package.json
@@ -10,9 +10,8 @@
   "config": {
     "nyc": {
       "exclude": [
-        "node_modules/",
-        "blarg/",
-        "blerg/"
+        "blarg",
+        "blerg"
       ]
     }
   }

--- a/test/nyc-test.js
+++ b/test/nyc-test.js
@@ -67,7 +67,7 @@ describe('nyc', function () {
         cwd: path.resolve(__dirname, './fixtures')
       })
 
-      nyc.exclude.length.should.eql(3)
+      nyc.exclude.length.should.eql(6)
     })
   })
 


### PR DESCRIPTION
An attempt at improving file exclusion.

Since there are breaking changes here I decided to work off of the babel branch which already has a major semver change associated with it. Documentation may need to be adjusted.

Changes:
- Always exclude `node_modules`
- Exclude using glob/minimatch patterns instead of RegExp (breaking change)
- addAllFiles now excludes during glob.sync, significantly improving performance

I also have ideas for an include key, backed by glob, based on this PR.