### PR TITLE
Exclusion improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,19 +104,31 @@ nyc report --reporter=lcov
 
 ## Excluding Files
 
-By default nyc does not instrument files in `node_modules`, or `test`
-for coverage. You can override this setting in your package.json, by
-adding the following configuration:
+You can tell nyc to ignore specific files and directories by adding
+an `config.nyc.exclude` array to your `package.json`. Each element of
+the array is a glob pattern indicating which paths should be omitted.
 
-```js
+Globs are matched using [minimatch](https://github.com/isaacs/minimatch)
+
+In addition to patterns specified in the package, nyc will always ignore
+files in `node_modules`.
+
+For example, the following config will ignore all of `node_modules`,
+any files with the extension `.spec.js`, and anything in the `build/`
+directory:
+
+```json
 {"config": {
   "nyc": {
     "exclude": [
-      "node_modules/"
+      "**/*.spec.js",
+      "build/**"
     ]
   }
 }}
 ```
+
+> Note: exclude defaults to [`test`, `test.js`].
 
 ## Include Reports For Files That Are Not Required
 

--- a/README.md
+++ b/README.md
@@ -104,17 +104,17 @@ nyc report --reporter=lcov
 
 ## Excluding Files
 
-You can tell nyc to ignore specific files and directories by adding
+You can tell nyc to exclude specific files and directories by adding
 an `config.nyc.exclude` array to your `package.json`. Each element of
 the array is a glob pattern indicating which paths should be omitted.
 
 Globs are matched using [minimatch](https://github.com/isaacs/minimatch)
 
-In addition to patterns specified in the package, nyc will always ignore
+In addition to patterns specified in the package, nyc will always exclude
 files in `node_modules`.
 
-For example, the following config will ignore all of `node_modules`,
-any files with the extension `.spec.js`, and anything in the `build/`
+For example, the following config will exclude all `node_modules`,
+any files with the extension `.spec.js`, and anything in the `build`
 directory:
 
 ```json
@@ -122,13 +122,14 @@ directory:
   "nyc": {
     "exclude": [
       "**/*.spec.js",
-      "build/**"
+      "build"
     ]
   }
 }}
 ```
 
-> Note: exclude defaults to [`test`, `test.js`].
+> Note: exclude defaults to `['test', 'test{,-*}.js']`, which would exclude
+the `test` directory as well as `test.js` and `test-*.js` files
 
 ## Include Reports For Files That Are Not Required
 

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function NYC (opts) {
   config = config.nyc || {}
 
   // load exclude stanza from config.
-  this.exclude = ['node_modules/**'].concat(config.exclude || ['test/**', 'test.js'])
+  this.exclude = ['**/node_modules/**'].concat(config.exclude || ['test/**', 'test{,-*}.js'])
   if (!Array.isArray(this.exclude)) this.exclude = [this.exclude]
   this.exclude = this._prepExcludePatterns(this.exclude)
 

--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ NYC.prototype._prepExcludePatterns = function (excludes) {
 
     // Allow gitignore style of directory exclusion
     if (!_.endsWith(exclude, '/**')) {
-      directories.push(exclude.concat('/**'))
+      directories.push(exclude.replace(/\/$/, '').concat('/**'))
     }
 
     return exclude

--- a/index.js
+++ b/index.js
@@ -116,6 +116,11 @@ NYC.prototype.addContent = function (filename, content) {
 }
 
 NYC.prototype.shouldInstrumentFile = function (relFile) {
+  // Remove leading "current folder" prefix
+  if (_.startsWith(relFile, './')) {
+    relFile = relFile.slice(2)
+  }
+
   // only instrument a file if it's not on the exclude list.
   for (var i = 0, exclude; (exclude = this.exclude[i]) !== undefined; i++) {
     if (minimatch(relFile, exclude)) {

--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ NYC.prototype.addContent = function (filename, content) {
   }
 }
 
-NYC.prototype.shouldInstrumentFile = function (relFile, returnImmediately) {
+NYC.prototype.shouldInstrumentFile = function (relFile) {
   // only instrument a file if it's not on the exclude list.
   for (var i = 0, exclude; (exclude = this.exclude[i]) !== undefined; i++) {
     if (minimatch(relFile, exclude)) {

--- a/index.js
+++ b/index.js
@@ -31,9 +31,9 @@ function NYC (opts) {
   config = config.nyc || {}
 
   // load exclude stanza from config.
-  this.exclude = ['node_modules'].concat(config.exclude || ['test', 'test.js'])
+  this.exclude = ['node_modules/**'].concat(config.exclude || ['test/**', 'test.js'])
   if (!Array.isArray(this.exclude)) this.exclude = [this.exclude]
-  this.exclude = this._excludeDirs(this.exclude)
+  this.exclude = this._prepExcludePatterns(this.exclude)
 
   // require extensions can be provided as config in package.json.
   this.require = config.require ? config.require : this.require
@@ -64,11 +64,22 @@ NYC.prototype._createInstrumenter = function () {
   })
 }
 
-NYC.prototype._excludeDirs = function (excludes) {
-  var appendix = _.map(excludes, function (exclude) {
-    return exclude + '/**'
+NYC.prototype._prepExcludePatterns = function (excludes) {
+  var directories = []
+  excludes = _.map(excludes, function (exclude) {
+    // Remove leading "current folder" prefix
+    if (_.startsWith(exclude, './')) {
+      exclude = exclude.slice(2)
+    }
+
+    // Allow gitignore style of directory exclusion
+    if (!_.endsWith(exclude, '/**')) {
+      directories.push(exclude.concat('/**'))
+    }
+
+    return exclude
   })
-  return _.union(excludes, appendix)
+  return _.union(excludes, directories)
 }
 
 NYC.prototype.addFile = function (filename, returnImmediately) {

--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ NYC.prototype._prepExcludePatterns = function (excludes) {
 
 NYC.prototype.addFile = function (filename, returnImmediately) {
   var relFile = path.relative(this.cwd, filename)
-  var instrument = this.shouldInstrumentFile(relFile)
+  var instrument = this.shouldInstrumentFile(relFile, filename)
   var content = stripBom(fs.readFileSync(filename, 'utf8'))
 
   if (instrument) {
@@ -102,7 +102,7 @@ NYC.prototype.addFile = function (filename, returnImmediately) {
 
 NYC.prototype.addContent = function (filename, content) {
   var relFile = path.relative(this.cwd, filename)
-  var instrument = this.shouldInstrumentFile(relFile)
+  var instrument = this.shouldInstrumentFile(relFile, filename)
 
   if (instrument) {
     content = this.instrumenter.instrumentSync(content, './' + relFile)
@@ -115,15 +115,14 @@ NYC.prototype.addContent = function (filename, content) {
   }
 }
 
-NYC.prototype.shouldInstrumentFile = function (relFile) {
-  // Remove leading "current folder" prefix
-  if (_.startsWith(relFile, './')) {
-    relFile = relFile.slice(2)
-  }
+NYC.prototype.shouldInstrumentFile = function () {
+  var filePaths = _.toArray(arguments).map(function (filePath) {
+    return path.normalize(filePath)
+  })
 
   // only instrument a file if it's not on the exclude list.
   for (var i = 0, exclude; (exclude = this.exclude[i]) !== undefined; i++) {
-    if (minimatch(relFile, exclude)) {
+    if (minimatch.match(filePaths, exclude).length) {
       return false
     }
   }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "glob": "^5.0.14",
     "istanbul": "^0.3.19",
     "lodash": "^3.10.0",
+    "minimatch": "^3.0.0",
     "mkdirp": "^0.5.0",
     "rimraf": "^2.4.2",
     "signal-exit": "^2.1.1",

--- a/test/fixtures/package.json
+++ b/test/fixtures/package.json
@@ -10,9 +10,8 @@
   "config": {
     "nyc": {
       "exclude": [
-        "node_modules/",
-        "blarg/",
-        "blerg/"
+        "blarg",
+        "blerg"
       ]
     }
   }

--- a/test/nyc-test.js
+++ b/test/nyc-test.js
@@ -67,7 +67,34 @@ describe('nyc', function () {
         cwd: path.resolve(__dirname, './fixtures')
       })
 
-      nyc.exclude.length.should.eql(6)
+      nyc.exclude.length.should.eql(5)
+    })
+  })
+
+  describe('_prepExcludePatterns', function () {
+    it('should adjust patterns appropriately', function () {
+      var _prepExcludePatterns = NYC.prototype._prepExcludePatterns
+
+      var result = _prepExcludePatterns(['./foo', 'bar/**'])
+
+      result.should.deep.equal(['foo', 'bar/**', 'foo/**'])
+    })
+  })
+
+  describe('shouldInstrumentFile', function () {
+    it('should exclude appropriately', function () {
+      var nyc = new NYC({
+        cwd: fixtures
+      })
+      var shouldInstrumentFile = nyc.shouldInstrumentFile.bind(nyc)
+
+      // config.excludes: "blarg", "blerg"
+      // nyc always excludes "node_modules/**"
+      shouldInstrumentFile('foo').should.equal(true)
+      shouldInstrumentFile('node_modules/bar').should.equal(false)
+      shouldInstrumentFile('blarg').should.equal(false)
+      shouldInstrumentFile('blarg/foo.js').should.equal(false)
+      shouldInstrumentFile('blerg').should.equal(false)
     })
   })
 

--- a/test/nyc-test.js
+++ b/test/nyc-test.js
@@ -123,6 +123,27 @@ describe('nyc', function () {
       shouldInstrumentFile('blerg').should.equal(false)
       shouldInstrumentFile('./blerg').should.equal(false)
     })
+
+    it('should handle example symlinked node_module', function () {
+      var nyc = new NYC({
+        cwd: fixtures
+      })
+      var shouldInstrumentFile = nyc.shouldInstrumentFile.bind(nyc)
+
+      var relPath = '../../nyc/node_modules/glob/glob.js'
+      var fullPath = '/Users/user/nyc/node_modules/glob/glob.js'
+
+      // Relative path will sneak past minimatch
+      // Leading dot causes problems
+      shouldInstrumentFile(relPath).should.equal(true)
+
+      // Full path should be excluded (node_modules)
+      shouldInstrumentFile(fullPath).should.equal(false)
+
+      // Send both relative and absolute path
+      // Results in exclusion (include = false)
+      shouldInstrumentFile(relPath, fullPath).should.equal(false)
+    })
   })
 
   describe('wrap', function () {

--- a/test/nyc-test.js
+++ b/test/nyc-test.js
@@ -67,7 +67,7 @@ describe('nyc', function () {
         cwd: path.resolve(__dirname, './fixtures')
       })
 
-      nyc.exclude.length.should.eql(3)
+      nyc.exclude.length.should.eql(6)
     })
   })
 


### PR DESCRIPTION
An attempt at improving file exclusion.

The biggest improvement appears when using the `--all` flag.

Changes:
- Always exclude `node_modules`
- Exclude using glob/minimatch patterns instead of RegExp (breaking change)
- addAllFiles now excludes during glob.sync, significantly improving performance

Resolves:
- #56: Exclude now uses glob patterns via minimatch

Complicates:
- #50: node_modules are now always excluded

Feel free to question my changes/decisions. I am open to compromise if necessary.