### PR TITLE
Improve source maps

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,6 +71,7 @@ NYC.prototype.addFile = function (filename, returnImmediately) {
   var content = stripBom(fs.readFileSync(filename, 'utf8'))
 
   if (instrument) {
+    this.sourceMapCache.add(filename, content)
     content = this.instrumenter.instrumentSync(content, './' + relFile)
   } else if (returnImmediately) {
     return {}

--- a/lib/source-map-cache.js
+++ b/lib/source-map-cache.js
@@ -11,7 +11,7 @@ function SourceMapCache (opts) {
 }
 
 SourceMapCache.prototype.add = function (filename, source) {
-  var sourceMap = convertSourceMap.fromSource(source)
+  var sourceMap = convertSourceMap.fromSource(source) || convertSourceMap.fromMapFileSource(source, path.dirname(filename))
   if (sourceMap) this.cache['./' + path.relative(this.cwd, filename)] = new SourceMapConsumer(sourceMap.sourcemap)
 }
 

--- a/lib/source-map-cache.js
+++ b/lib/source-map-cache.js
@@ -20,14 +20,29 @@ SourceMapCache.prototype.applySourceMaps = function (coverage) {
   var mappedCoverage = _.cloneDeep(coverage)
 
   Object.keys(coverage).forEach(function (key) {
-    if (_this.cache[key]) {
-      _this._rewriteStatements(mappedCoverage[key], _this.cache[key])
-      _this._rewriteFunctions(mappedCoverage[key], _this.cache[key])
-      _this._rewriteBranches(mappedCoverage[key], _this.cache[key])
+    var sourceMap = _this.cache[key]
+    if (!sourceMap) {
+      return
     }
+
+    var fileCoverage = mappedCoverage[key]
+    _this._rewritePath(mappedCoverage, fileCoverage, sourceMap)
+    _this._rewriteStatements(fileCoverage, sourceMap)
+    _this._rewriteFunctions(fileCoverage, sourceMap)
+    _this._rewriteBranches(fileCoverage, sourceMap)
   })
 
   return mappedCoverage
+}
+
+SourceMapCache.prototype._rewritePath = function (mappedCoverage, coverage, sourceMap) {
+  // only rewrite the path if the file comes from a single source
+  if (sourceMap.sources.length !== 1) return
+
+  var originalPath = './' + path.join(path.dirname(coverage.path), sourceMap.sources[0])
+  delete mappedCoverage[coverage.path]
+  coverage.path = originalPath
+  mappedCoverage[originalPath] = coverage
 }
 
 SourceMapCache.prototype._rewriteStatements = function (coverage, sourceMap) {


### PR DESCRIPTION
First of, thanks for adding source map support! I've been trying to use `nyc@4` with the [project](https://github.com/novemberborn/buoyant) that lead to my [code coverage article](https://medium.com/@novemberborn/code-coverage-with-babel-istanbul-nyc-83b8c2f1093#.29ern9dza) from last week. I got it working but had to make some changes. This is the second PR which covers the source map handling.

---

I'm now caching a source map if a file is added, even if the dependency wasn't loaded via a custom require hook. This helps with cases where the file was compiled using say a watcher.

nyc now also loads source maps that are merely referenced by the source file.

Finally, if the covered file came from a single source (according to its source map), the `path` is rewritten to the original source. Subsequent reports that include the file content, like the HTML report, will now show the correct content.

Without rewriting the path the HTML report will show compiled output highlighted using the remapped coverage information.

If there are two or more sources the compiled output will be shown, with the wrong coverage information. I'm not sure how to split coverage over multiple source files. Hopefully that's an edge-case.

It's getting late in the day in my timezone so I haven't had a chance to update the tests to cover this new behavior. The coverage report for my own project looks the same as it did previously with my more custom setup so that's encouraging.