### PR TITLE
exclude coverage folder when instrumenting

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "nyc": {
       "exclude": [
         "node_modules",
-        "bin"
+        "bin",
+        "coverage"
       ]
     }
   },


### PR DESCRIPTION
An HTML report may be generated during development. This report contains JS files that should not be instrumented when running the test suite.