### PR TITLE
use capture-require

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var _ = require('lodash')
 var fs = require('fs')
 var glob = require('glob')
 var mkdirp = require('mkdirp')
-var Module = require('module')
+var captureRequire = require('capture-require')
 var path = require('path')
 var rimraf = require('rimraf')
 var onExit = require('signal-exit')
@@ -138,54 +138,12 @@ NYC.prototype.addAllFiles = function () {
 NYC.prototype._wrapRequire = function () {
   var _this = this
 
-  var defaultHook = function (module, filename) {
-    // instrument the required file.
-    var obj = _this.addFile(filename, false)
+  captureRequire(function (module, compiledSrc, filename) {
+    _this.sourceMapCache.add(filename, compiledSrc)
 
-    // always use node's original _compile method to compile the instrumented
-    // code. if a custom hook invoked the default hook the code should not be
-    // compiled using the custom hook.
-    Module.prototype._compile.call(module, obj.content, filename)
-  }
-
-  var wrapCustomHook = function (hook) {
-    return function (module, filename) {
-      // override the _compile method so the code can be instrumented first.
-      module._compile = function (compiledSrc) {
-        _this.sourceMapCache.add(filename, compiledSrc)
-
-        // now instrument the compiled code.
-        var obj = _this.addContent(filename, compiledSrc)
-        Module.prototype._compile.call(module, obj.content, filename)
-      }
-
-      // allow the custom hook to compile the code. it can fall back to the
-      // default hook if necessary (accessed via require.extensions['.js'] prior
-      // to setting itself)
-      hook(module, filename)
-    }
-  }
-
-  var requireHook = defaultHook
-  // track existing hooks so they can be restored without wrapping them a second
-  // time.
-  var hooks = [requireHook]
-
-  // use a getter and setter to capture any external require hooks that are
-  // registered, e.g., babel-core/register
-  require.extensions.__defineGetter__('.js', function () {
-    return requireHook
-  })
-
-  require.extensions.__defineSetter__('.js', function (hook) {
-    var restoreIndex = hooks.indexOf(hook)
-    if (restoreIndex !== -1) {
-      requireHook = hook
-      hooks.splice(restoreIndex + 1, hooks.length)
-    } else {
-      requireHook = wrapCustomHook(hook)
-      hooks.push(requireHook)
-    }
+    // now instrument the compiled code.
+    var obj = _this.addContent(filename, compiledSrc)
+    module._compile(obj.content, filename)
   })
 }
 

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "yargs": "^3.15.0"
   },
   "devDependencies": {
+    "capture-require": "^0.1.0",
     "chai": "^3.0.0",
     "sinon": "^1.15.3",
     "source-map-fixtures": "^0.1.0",


### PR DESCRIPTION
Well, this doesn't work, but I am a bit stumped as to why.

It no longer distinguishes between `default` and `wrapped` (it just uses the wrapping function to wrap the current top of `require.extensions['.js']`). This also means it never calls `addFile`, but addFile isn't really necessary. The default `require.extensions['.js']` should be forwarding you the content anyway.

@novemberborn - can you take a look and give me a guess as to why those tests are failing (like what information `nyc` isn't collecting correctly). I've spent quite a bit of time groking the `wrapRequire` section of the `nyc` codebase, but haven't really dived deep anywhere else.

I will keep trying, just hoping for another set of eyeballs.