### PR TITLE
proposal: split into one test per file

### DIFF
--- a/test/wraps-modules-with-coverage-counters.js
+++ b/test/wraps-modules-with-coverage-counters.js
@@ -1,0 +1,22 @@
+/* global it */
+
+var NYC = require('../')
+
+require('chai').should()
+require('tap').mochaGlobals()
+
+it('wraps modules with coverage counters when they are required', function () {
+  var nyc = new NYC({
+    cwd: process.cwd()
+  })
+  nyc.wrap()
+
+  // clear the module cache so that
+  // we pull index.js in again and wrap it.
+  var name = require.resolve('../')
+  delete require.cache[name]
+
+  // when we require index.js it should be wrapped.
+  var index = require('../')
+  index.should.match(/__cov_/)
+})


### PR DESCRIPTION
This solves #80, and fixes the problems I was having integrating `capture-require` (at least for the one test I've actually separated out so far).

I really do not like this, but I am not sure of an easier way to pull it off.