### PR TITLE
glob-based include/exclude functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Upcoming
 
+- [#84](https://github.com/bcoe/nyc/pull/84) glob based include/exlude of files (@Lalem001)
+- [#78](https://github.com/bcoe/nyc/pull/78) improvements to sourcemap tests (@novemberborn)
+- [#73](https://github.com/bcoe/nyc/pull/73) improvements to require tests (@novemberborn)
 - [#65](https://github.com/bcoe/nyc/pull/65) significant improvements to require hooks (@novemberborn)
 - [#64](https://github.com/bcoe/nyc/pull/64) upgrade Istanbul (@novemberborn)
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ You can tell nyc to exclude specific files and directories by adding
 an `config.nyc.exclude` array to your `package.json`. Each element of
 the array is a glob pattern indicating which paths should be omitted.
 
-Globs are matched using [minimatch](https://github.com/isaacs/minimatch)
+Globs are matched using [micromatch](https://www.npmjs.com/package/micromatch)
 
 In addition to patterns specified in the package, nyc will always exclude
 files in `node_modules`.
@@ -119,6 +119,19 @@ directory:
 
 > Note: exclude defaults to `['test', 'test{,-*}.js']`, which would exclude
 the `test` directory as well as `test.js` and `test-*.js` files
+
+## Including Files
+
+As an alternative to providing a list of files to `exclude`, you can provide
+an `include` key to specify specific files that should be covered:
+
+```json
+{"config": {
+  "nyc": {
+    "include": ["**/build/umd/moment.js"]
+  }
+}}
+```
 
 ## Include Reports For Files That Are Not Required
 

--- a/README.md
+++ b/README.md
@@ -93,17 +93,17 @@ nyc report --reporter=lcov
 
 ## Excluding Files
 
-You can tell nyc to ignore specific files and directories by adding
+You can tell nyc to exclude specific files and directories by adding
 an `config.nyc.exclude` array to your `package.json`. Each element of
 the array is a glob pattern indicating which paths should be omitted.
 
 Globs are matched using [minimatch](https://github.com/isaacs/minimatch)
 
-In addition to patterns specified in the package, nyc will always ignore
+In addition to patterns specified in the package, nyc will always exclude
 files in `node_modules`.
 
-For example, the following config will ignore all of `node_modules`,
-any files with the extension `.spec.js`, and anything in the `build/`
+For example, the following config will exclude all `node_modules`,
+any files with the extension `.spec.js`, and anything in the `build`
 directory:
 
 ```json
@@ -111,13 +111,14 @@ directory:
   "nyc": {
     "exclude": [
       "**/*.spec.js",
-      "build/**"
+      "build"
     ]
   }
 }}
 ```
 
-> Note: exclude defaults to [`test`, `test.js`].
+> Note: exclude defaults to `['test', 'test{,-*}.js']`, which would exclude
+the `test` directory as well as `test.js` and `test-*.js` files
 
 ## Include Reports For Files That Are Not Required
 

--- a/README.md
+++ b/README.md
@@ -93,19 +93,31 @@ nyc report --reporter=lcov
 
 ## Excluding Files
 
-By default nyc does not instrument files in `node_modules`, or `test`
-for coverage. You can override this setting in your package.json, by
-adding the following configuration:
+You can tell nyc to ignore specific files and directories by adding
+an `config.nyc.exclude` array to your `package.json`. Each element of
+the array is a glob pattern indicating which paths should be omitted.
 
-```js
+Globs are matched using [minimatch](https://github.com/isaacs/minimatch)
+
+In addition to patterns specified in the package, nyc will always ignore
+files in `node_modules`.
+
+For example, the following config will ignore all of `node_modules`,
+any files with the extension `.spec.js`, and anything in the `build/`
+directory:
+
+```json
 {"config": {
   "nyc": {
     "exclude": [
-      "node_modules/"
+      "**/*.spec.js",
+      "build/**"
     ]
   }
 }}
 ```
+
+> Note: exclude defaults to [`test`, `test.js`].
 
 ## Include Reports For Files That Are Not Required
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ an `include` key to specify specific files that should be covered:
 }}
 ```
 
+> Note: include defaults to `['**']`
+
 ## Include Reports For Files That Are Not Required
 
 By default nyc does not collect coverage for files that have not
@@ -174,7 +176,7 @@ npm install coveralls nyc --save
 {
   "script": {
     "test": "nyc tap ./test/*.js",
-    "coverage": "nyc report --reporter=text-lcov | coveralls",
+    "coverage": "nyc npm test && nyc report --reporter=text-lcov | coveralls",
   }
 }
 ```
@@ -190,5 +192,4 @@ after_success: npm run coverage
 
 That's all there is to it!
 
-_Note: by default coveralls.io adds comments to pull-requests on GitHub, this can
-feel intrusive. To disable this, click on your repo on coveralls.io and uncheck `LEAVE COMMENTS?`._
+> Note: by default coveralls.io adds comments to pull-requests on GitHub, this can feel intrusive. To disable this, click on your repo on coveralls.io and uncheck `LEAVE COMMENTS?`._

--- a/index.js
+++ b/index.js
@@ -125,6 +125,11 @@ NYC.prototype.addContent = function (filename, content) {
 }
 
 NYC.prototype.shouldInstrumentFile = function (relFile) {
+  // Remove leading "current folder" prefix
+  if (_.startsWith(relFile, './')) {
+    relFile = relFile.slice(2)
+  }
+
   // only instrument a file if it's not on the exclude list.
   for (var i = 0, exclude; (exclude = this.exclude[i]) !== undefined; i++) {
     if (minimatch(relFile, exclude)) {

--- a/index.js
+++ b/index.js
@@ -32,7 +32,9 @@ function NYC (opts) {
   config = config.nyc || {}
 
   // load exclude stanza from config.
-  this.include = this._prepGlobPatterns(config.include)
+  this.include = config.include || ['**']
+  this.include = this._prepGlobPatterns(this.include)
+
   this.exclude = ['**/node_modules/**'].concat(config.exclude || ['test/**', 'test{,-*}.js'])
   if (!Array.isArray(this.exclude)) this.exclude = [this.exclude]
   this.exclude = this._prepGlobPatterns(this.exclude)
@@ -78,11 +80,6 @@ NYC.prototype._prepGlobPatterns = function (patterns) {
 
   var directories = []
   patterns = _.map(patterns, function (pattern) {
-    // Remove leading "current folder" prefix
-    if (_.startsWith(pattern, './')) {
-      pattern = pattern.slice(2)
-    }
-
     // Allow gitignore style of directory exclusion
     if (!_.endsWith(pattern, '/**')) {
       directories.push(pattern.replace(/\/$/, '').concat('/**'))
@@ -130,11 +127,8 @@ NYC.prototype.addContent = function (filename, content) {
 NYC.prototype.shouldInstrumentFile = function (filename, relFile) {
   relFile = relFile.replace(/^\.\//, '') // remove leading './'.
 
-  if (this.include) {
-    return micromatch.any(filename, this.include) || micromatch.any(relFile, this.include)
-  } else {
-    return !(micromatch.any(filename, this.exclude) || micromatch.any(relFile, this.exclude))
-  }
+  return (micromatch.any(filename, this.include) || micromatch.any(relFile, this.include)) &&
+    !(micromatch.any(filename, this.exclude) || micromatch.any(relFile, this.exclude))
 }
 
 NYC.prototype.addAllFiles = function () {

--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ NYC.prototype.addContent = function (filename, content) {
   }
 }
 
-NYC.prototype.shouldInstrumentFile = function (relFile, returnImmediately) {
+NYC.prototype.shouldInstrumentFile = function (relFile) {
   // only instrument a file if it's not on the exclude list.
   for (var i = 0, exclude; (exclude = this.exclude[i]) !== undefined; i++) {
     if (minimatch(relFile, exclude)) {

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 var _ = require('lodash')
 var fs = require('fs')
 var glob = require('glob')
+var minimatch = require('minimatch')
 var mkdirp = require('mkdirp')
 var Module = require('module')
 var path = require('path')
@@ -31,11 +32,9 @@ function NYC (opts) {
   config = config.nyc || {}
 
   // load exclude stanza from config.
-  this.exclude = config.exclude || ['node_modules[\/\\\\]', 'test[\/\\\\]', 'test\\.js']
+  this.exclude = ['node_modules'].concat(config.exclude || ['test', 'test.js'])
   if (!Array.isArray(this.exclude)) this.exclude = [this.exclude]
-  this.exclude = _.map(this.exclude, function (p) {
-    return new RegExp(p)
-  })
+  this.exclude = this._excludeDirs(this.exclude)
 
   // require extensions can be provided as config in package.json.
   this.require = config.require ? config.require : this.require
@@ -71,6 +70,13 @@ NYC.prototype._createInstrumenter = function () {
     noCompact: !instrumenterConfig.compact,
     preserveComments: instrumenterConfig['preserve-comments']
   })
+}
+
+NYC.prototype._excludeDirs = function (excludes) {
+  var appendix = _.map(excludes, function (exclude) {
+    return exclude + '/**'
+  })
+  return _.union(excludes, appendix)
 }
 
 NYC.prototype.addFile = function (filename, returnImmediately) {
@@ -110,7 +116,7 @@ NYC.prototype.addContent = function (filename, content) {
 NYC.prototype.shouldInstrumentFile = function (relFile, returnImmediately) {
   // only instrument a file if it's not on the exclude list.
   for (var i = 0, exclude; (exclude = this.exclude[i]) !== undefined; i++) {
-    if (exclude.test(relFile)) {
+    if (minimatch(relFile, exclude)) {
       return false
     }
   }
@@ -122,7 +128,7 @@ NYC.prototype.addAllFiles = function () {
 
   this._createOutputDirectory()
 
-  glob.sync('**/*.js', {nodir: true}).forEach(function (filename) {
+  glob.sync('**/*.js', {nodir: true, ignore: this.exclude}).forEach(function (filename) {
     var obj = _this.addFile(filename, true)
     if (obj.instrument) {
       module._compile(

--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ NYC.prototype._prepExcludePatterns = function (excludes) {
 
     // Allow gitignore style of directory exclusion
     if (!_.endsWith(exclude, '/**')) {
-      directories.push(exclude.concat('/**'))
+      directories.push(exclude.replace(/\/$/, '').concat('/**'))
     }
 
     return exclude

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ function NYC (opts) {
   config = config.nyc || {}
 
   // load exclude stanza from config.
-  this.exclude = ['node_modules/**'].concat(config.exclude || ['test/**', 'test.js'])
+  this.exclude = ['**/node_modules/**'].concat(config.exclude || ['test/**', 'test{,-*}.js'])
   if (!Array.isArray(this.exclude)) this.exclude = [this.exclude]
   this.exclude = this._prepExcludePatterns(this.exclude)
 

--- a/index.js
+++ b/index.js
@@ -32,9 +32,9 @@ function NYC (opts) {
   config = config.nyc || {}
 
   // load exclude stanza from config.
-  this.exclude = ['node_modules'].concat(config.exclude || ['test', 'test.js'])
+  this.exclude = ['node_modules/**'].concat(config.exclude || ['test/**', 'test.js'])
   if (!Array.isArray(this.exclude)) this.exclude = [this.exclude]
-  this.exclude = this._excludeDirs(this.exclude)
+  this.exclude = this._prepExcludePatterns(this.exclude)
 
   // require extensions can be provided as config in package.json.
   this.require = config.require ? config.require : this.require
@@ -72,11 +72,22 @@ NYC.prototype._createInstrumenter = function () {
   })
 }
 
-NYC.prototype._excludeDirs = function (excludes) {
-  var appendix = _.map(excludes, function (exclude) {
-    return exclude + '/**'
+NYC.prototype._prepExcludePatterns = function (excludes) {
+  var directories = []
+  excludes = _.map(excludes, function (exclude) {
+    // Remove leading "current folder" prefix
+    if (_.startsWith(exclude, './')) {
+      exclude = exclude.slice(2)
+    }
+
+    // Allow gitignore style of directory exclusion
+    if (!_.endsWith(exclude, '/**')) {
+      directories.push(exclude.concat('/**'))
+    }
+
+    return exclude
   })
-  return _.union(excludes, appendix)
+  return _.union(excludes, directories)
 }
 
 NYC.prototype.addFile = function (filename, returnImmediately) {

--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ NYC.prototype._prepExcludePatterns = function (excludes) {
 
 NYC.prototype.addFile = function (filename, returnImmediately) {
   var relFile = path.relative(this.cwd, filename)
-  var instrument = this.shouldInstrumentFile(relFile)
+  var instrument = this.shouldInstrumentFile(relFile, filename)
   var content = stripBom(fs.readFileSync(filename, 'utf8'))
 
   if (instrument) {
@@ -111,7 +111,7 @@ NYC.prototype.addFile = function (filename, returnImmediately) {
 
 NYC.prototype.addContent = function (filename, content) {
   var relFile = path.relative(this.cwd, filename)
-  var instrument = this.shouldInstrumentFile(relFile)
+  var instrument = this.shouldInstrumentFile(relFile, filename)
 
   if (instrument) {
     content = this.instrumenter.instrumentSync(content, './' + relFile)
@@ -124,15 +124,14 @@ NYC.prototype.addContent = function (filename, content) {
   }
 }
 
-NYC.prototype.shouldInstrumentFile = function (relFile) {
-  // Remove leading "current folder" prefix
-  if (_.startsWith(relFile, './')) {
-    relFile = relFile.slice(2)
-  }
+NYC.prototype.shouldInstrumentFile = function () {
+  var filePaths = _.toArray(arguments).map(function (filePath) {
+    return path.normalize(filePath)
+  })
 
   // only instrument a file if it's not on the exclude list.
   for (var i = 0, exclude; (exclude = this.exclude[i]) !== undefined; i++) {
-    if (minimatch(relFile, exclude)) {
+    if (minimatch.match(filePaths, exclude).length) {
       return false
     }
   }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "glob": "^5.0.14",
     "istanbul": "^0.4.1",
     "lodash": "^3.10.0",
+    "minimatch": "^3.0.0",
     "mkdirp": "^0.5.0",
     "rimraf": "^2.4.2",
     "signal-exit": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "node_modules",
         "bin",
         "coverage",
+        "test/fixtures/coverage.js",
         "test/nyc-test.js",
         "test/source-map-cache.js",
         "test/fixtures/_generateCoverage.js"
@@ -51,7 +52,7 @@
     "glob": "^5.0.14",
     "istanbul": "^0.4.1",
     "lodash": "^3.10.0",
-    "minimatch": "^3.0.0",
+    "micromatch": "^2.1.6",
     "mkdirp": "^0.5.0",
     "rimraf": "^2.4.2",
     "signal-exit": "^2.1.1",

--- a/test/fixtures/package.json
+++ b/test/fixtures/package.json
@@ -10,8 +10,8 @@
   "config": {
     "nyc": {
       "exclude": [
-        "blarg",
-        "blerg"
+        "**/blarg",
+        "**/blerg"
       ]
     }
   }

--- a/test/fixtures/package.json
+++ b/test/fixtures/package.json
@@ -10,9 +10,8 @@
   "config": {
     "nyc": {
       "exclude": [
-        "node_modules/",
-        "blarg/",
-        "blerg/"
+        "blarg",
+        "blerg"
       ]
     }
   }

--- a/test/nyc-test.js
+++ b/test/nyc-test.js
@@ -43,7 +43,34 @@ describe('nyc', function () {
         cwd: path.resolve(__dirname, './fixtures')
       })
 
-      nyc.exclude.length.should.eql(6)
+      nyc.exclude.length.should.eql(5)
+    })
+  })
+
+  describe('_prepExcludePatterns', function () {
+    it('should adjust patterns appropriately', function () {
+      var _prepExcludePatterns = NYC.prototype._prepExcludePatterns
+
+      var result = _prepExcludePatterns(['./foo', 'bar/**'])
+
+      result.should.deep.equal(['foo', 'bar/**', 'foo/**'])
+    })
+  })
+
+  describe('shouldInstrumentFile', function () {
+    it('should exclude appropriately', function () {
+      var nyc = new NYC({
+        cwd: fixtures
+      })
+      var shouldInstrumentFile = nyc.shouldInstrumentFile.bind(nyc)
+
+      // config.excludes: "blarg", "blerg"
+      // nyc always excludes "node_modules/**"
+      shouldInstrumentFile('foo').should.equal(true)
+      shouldInstrumentFile('node_modules/bar').should.equal(false)
+      shouldInstrumentFile('blarg').should.equal(false)
+      shouldInstrumentFile('blarg/foo.js').should.equal(false)
+      shouldInstrumentFile('blerg').should.equal(false)
     })
   })
 

--- a/test/nyc-test.js
+++ b/test/nyc-test.js
@@ -51,26 +51,53 @@ describe('nyc', function () {
     it('should adjust patterns appropriately', function () {
       var _prepExcludePatterns = NYC.prototype._prepExcludePatterns
 
-      var result = _prepExcludePatterns(['./foo', 'bar/**'])
+      var result = _prepExcludePatterns(['./foo', 'bar/**', 'baz/'])
 
-      result.should.deep.equal(['foo', 'bar/**', 'foo/**'])
+      result.should.deep.equal([
+        'foo',
+        'bar/**',
+        'baz/',
+        'foo/**', // Appended `/**`
+        'baz/**'  // Removed trailing slash before appending `/**`
+      ])
     })
   })
 
   describe('shouldInstrumentFile', function () {
-    it('should exclude appropriately', function () {
+    it('should exclude appropriately with defaults', function () {
+      var nyc = new NYC()
+
+      // Root package contains config.exclude
+      // Restore exclude to default patterns
+      nyc.exclude = nyc._prepExcludePatterns([
+        '**/node_modules/**',
+        'test/**',
+        'test{,-*}.js'
+      ])
+
+      var shouldInstrumentFile = nyc.shouldInstrumentFile.bind(nyc)
+
+      // nyc always excludes "node_modules/**"
+      shouldInstrumentFile('foo').should.equal(true)
+      shouldInstrumentFile('node_modules/bar').should.equal(false)
+      shouldInstrumentFile('foo/node_modules/bar').should.equal(false)
+      shouldInstrumentFile('test.js').should.equal(false)
+      shouldInstrumentFile('testfoo.js').should.equal(true)
+      shouldInstrumentFile('test-foo.js').should.equal(false)
+      shouldInstrumentFile('lib/test.js').should.equal(true)
+    })
+
+    it('should exclude appropriately with config.exclude', function () {
       var nyc = new NYC({
         cwd: fixtures
       })
       var shouldInstrumentFile = nyc.shouldInstrumentFile.bind(nyc)
 
       // config.excludes: "blarg", "blerg"
-      // nyc always excludes "node_modules/**"
-      shouldInstrumentFile('foo').should.equal(true)
-      shouldInstrumentFile('node_modules/bar').should.equal(false)
       shouldInstrumentFile('blarg').should.equal(false)
       shouldInstrumentFile('blarg/foo.js').should.equal(false)
       shouldInstrumentFile('blerg').should.equal(false)
+      shouldInstrumentFile('./blerg').should.equal(false)
     })
   })
 

--- a/test/nyc-test.js
+++ b/test/nyc-test.js
@@ -54,10 +54,10 @@ describe('nyc', function () {
       var result = _prepGlobPatterns(['./foo', 'bar/**', 'baz/'])
 
       result.should.deep.equal([
-        'foo',
+        './foo',
         'bar/**',
         'baz/',
-        'foo/**', // Appended `/**`
+        './foo/**', // Appended `/**`
         'baz/**'  // Removed trailing slash before appending `/**`
       ])
     })

--- a/test/nyc-test.js
+++ b/test/nyc-test.js
@@ -43,7 +43,7 @@ describe('nyc', function () {
         cwd: path.resolve(__dirname, './fixtures')
       })
 
-      nyc.exclude.length.should.eql(3)
+      nyc.exclude.length.should.eql(6)
     })
   })
 

--- a/test/nyc-test.js
+++ b/test/nyc-test.js
@@ -99,6 +99,27 @@ describe('nyc', function () {
       shouldInstrumentFile('blerg').should.equal(false)
       shouldInstrumentFile('./blerg').should.equal(false)
     })
+
+    it('should handle example symlinked node_module', function () {
+      var nyc = new NYC({
+        cwd: fixtures
+      })
+      var shouldInstrumentFile = nyc.shouldInstrumentFile.bind(nyc)
+
+      var relPath = '../../nyc/node_modules/glob/glob.js'
+      var fullPath = '/Users/user/nyc/node_modules/glob/glob.js'
+
+      // Relative path will sneak past minimatch
+      // Leading dot causes problems
+      shouldInstrumentFile(relPath).should.equal(true)
+
+      // Full path should be excluded (node_modules)
+      shouldInstrumentFile(fullPath).should.equal(false)
+
+      // Send both relative and absolute path
+      // Results in exclusion (include = false)
+      shouldInstrumentFile(relPath, fullPath).should.equal(false)
+    })
   })
 
   describe('wrap', function () {


### PR DESCRIPTION
A few slight tweaks to Lalem001's awesome work on glob-based excludes:

* I've switched to (at this time an older) version of `micromatch`. This works with leading `./` so that using `npm link` does not break exclusions.
* I've added support for `include` along with `exclude`.

Reviewers: @Lalem001, @davidchase, @novemberborn