### PR TITLE
wip! use tap.spawn() for each test

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "glob": "^5.0.14",
     "istanbul": "^0.4.1",
     "lodash": "^3.10.0",
-    "micromatch": "^2.1.6",
+    "micromatch": "~2.1.6",
     "mkdirp": "^0.5.0",
     "rimraf": "^2.4.2",
     "signal-exit": "^2.1.1",

--- a/test/fixtures/spawn.js
+++ b/test/fixtures/spawn.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+var spawn = require('child_process').spawn
+spawn(process.execPath, ['sigint.js'], { cwd: __dirname })
+spawn(process.execPath, ['sigterm.js'], { cwd: __dirname })


### PR DESCRIPTION
Another suggestion for #80. My "crazier idea" as mentioned in #83:

> My even crazier idea was to change the runner a little bit. Still one test file, but it starts each test in a child process and communicates the results. That means any shared setup code is still executed for each test without having to be duplicated.

* [x] some test failures, maybe due to #79 
* [x] `master` has 21 tests, this has 17, so some are not being executed