### PR TITLE
patch to make cmd shim work in subprocesses on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### Upcoming
 
-- [#84](https://github.com/bcoe/nyc/pull/84) glob based include/exlude of files (@Lalem001)
+- [#87](https://github.com/bcoe/nyc/pull/87) make spawn() work on Windows (@bcoe)
+- [#84](https://github.com/bcoe/nyc/pull/84) glob based include/exclude of files (@Lalem001)
 - [#78](https://github.com/bcoe/nyc/pull/78) improvements to sourcemap tests (@novemberborn)
 - [#73](https://github.com/bcoe/nyc/pull/73) improvements to require tests (@novemberborn)
 - [#65](https://github.com/bcoe/nyc/pull/65) significant improvements to require hooks (@novemberborn)

--- a/node_modules/spawn-wrap/index.js
+++ b/node_modules/spawn-wrap/index.js
@@ -127,10 +127,29 @@ function wrap (argv, env, workingDir) {
       options.envPairs.push((isWindows ? 'Path=' : 'PATH=') + workingDir)
     }
 
+    if (isWindows) fixWindowsBins(workingDir, options)
+
     return spawn.call(this, options)
   }
 
   return unwrap
+}
+
+// by default Windows will reference the full
+// path to the node.exe or iojs.exe as the bin,
+// we should instead point spawn() at our .cmd shim.
+function fixWindowsBins (workingDir, options) {
+  var renode = new RegExp('.*node\\.exe$')
+  var reiojs = new RegExp('.*iojs\\.exe$')
+
+  options.file = options.file.replace(renode, workingDir + '/node.cmd')
+  options.file = options.file.replace(reiojs, workingDir + '/node.cmd')
+
+  options.args = options.args.map(function (a) {
+    a = a.replace(renode, workingDir + '/node.cmd')
+    a = a.replace(reiojs, workingDir + '/node.cmd')
+    return a
+  })
 }
 
 function setup (argv, env) {


### PR DESCRIPTION
nyc works with subprocesses on my virtualbox testing image now:

<img width="680" alt="screen shot 2015-12-09 at 12 37 58 am" src="https://cloud.githubusercontent.com/assets/194609/11680439/1e78fe64-9e0d-11e5-9e67-b73deb10572c.png">

we still need to do some work to get the `nyc` tests themselves passing -- and I dream of one day getting back on the `latest` version of spawn-wrap so that we can stop bundling dependencies ... but, one step at a time.