### PR TITLE
use a tilde range for micromatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "glob": "^5.0.14",
     "istanbul": "^0.4.1",
     "lodash": "^3.10.0",
-    "micromatch": "^2.1.6",
+    "micromatch": "~2.1.6",
     "mkdirp": "^0.5.0",
     "rimraf": "^2.4.2",
     "signal-exit": "^2.1.1",


### PR DESCRIPTION
The intent was to use an older version of micromatch, but the current
semver specification allows up to latest.

The carrot range will allow any version up to, but not including 3.0.0.

Switched to a tilde range which allows up to, but not including 2.2.0.