### PR TITLE
adapt remap-istanbul's mapping logic for nyc

### DIFF
--- a/lib/source-map-cache.js
+++ b/lib/source-map-cache.js
@@ -35,6 +35,51 @@ SourceMapCache.prototype.applySourceMaps = function (coverage) {
   return mappedCoverage
 }
 
+// Maps the coverage location based on the source map. Adapted from getMapping()
+// in remap-istanbul:
+// <https://github.com/SitePen/remap-istanbul/blob/30b67ad3f24ba7e0da8b8888d5a7c3c8480d48b2/lib/remap.js#L55:L108>.
+function mapLocation (sourceMap, location) {
+  var start = sourceMap.originalPositionFor(location.start)
+  var end = sourceMap.originalPositionFor(location.end)
+
+  /* istanbul ignore if: edge case too hard to test for */
+  if (!start || !end) {
+    return null
+  }
+  if (!start.source || !end.source || start.source !== end.source) {
+    return null
+  }
+  /* istanbul ignore if: edge case too hard to test for */
+  if (start.line === null || start.column === null) {
+    return null
+  }
+  /* istanbul ignore if: edge case too hard to test for */
+  if (end.line === null || end.column === null) {
+    return null
+  }
+
+  if (start.line === end.line && start.column === end.column) {
+    end = sourceMap.originalPositionFor({
+      line: location.end.line,
+      column: location.end.column,
+      bias: 2
+    })
+    end.column = end.column - 1
+  }
+
+  return {
+    start: {
+      line: start.line,
+      column: start.column
+    },
+    end: {
+      line: end.line,
+      column: end.column
+    },
+    skip: location.skip
+  }
+}
+
 SourceMapCache.prototype._rewritePath = function (mappedCoverage, coverage, sourceMap) {
   // only rewrite the path if the file comes from a single source
   if (sourceMap.sources.length !== 1) return
@@ -46,22 +91,15 @@ SourceMapCache.prototype._rewritePath = function (mappedCoverage, coverage, sour
 }
 
 SourceMapCache.prototype._rewriteStatements = function (coverage, sourceMap) {
-  var start = null
-  var end = null
-
   var s = {}
   var statementMap = {}
   var index = 1
 
   Object.keys(coverage.statementMap).forEach(function (k) {
-    start = sourceMap.originalPositionFor({line: coverage.statementMap[k].start.line, column: coverage.statementMap[k].start.column})
-    end = sourceMap.originalPositionFor({line: coverage.statementMap[k].end.line, column: coverage.statementMap[k].end.column})
-    if (start.line && end.line) {
+    var mapped = mapLocation(sourceMap, coverage.statementMap[k])
+    if (mapped) {
       s[index + ''] = coverage.s[k]
-      statementMap[index + ''] = {
-        start: {line: start.line, column: start.column},
-        end: {line: end.line, column: end.column}
-      }
+      statementMap[index + ''] = mapped
       index++
     }
   })
@@ -71,28 +109,18 @@ SourceMapCache.prototype._rewriteStatements = function (coverage, sourceMap) {
 }
 
 SourceMapCache.prototype._rewriteFunctions = function (coverage, sourceMap) {
-  var start = null
-  var end = null
-  var line = null
-
   var f = {}
   var fnMap = {}
   var index = 1
 
   Object.keys(coverage.fnMap).forEach(function (k) {
-    start = sourceMap.originalPositionFor({line: coverage.fnMap[k].loc.start.line, column: coverage.fnMap[k].loc.start.column})
-    end = sourceMap.originalPositionFor({line: coverage.fnMap[k].loc.end.line, column: coverage.fnMap[k].loc.end.column})
-    line = sourceMap.originalPositionFor({line: coverage.fnMap[k].line, column: null})
-
-    if (line.line && start.line && end.line) {
+    var mapped = mapLocation(sourceMap, coverage.fnMap[k].loc)
+    if (mapped) {
       f[index + ''] = coverage.f[k]
       fnMap[index + ''] = {
         name: coverage.fnMap[k].name,
-        line: line.line,
-        loc: {
-          start: {line: start.line, column: start.column},
-          end: {line: end.line, column: end.column}
-        }
+        line: mapped.start.line,
+        loc: mapped
       }
       index++
     }
@@ -103,34 +131,30 @@ SourceMapCache.prototype._rewriteFunctions = function (coverage, sourceMap) {
 }
 
 SourceMapCache.prototype._rewriteBranches = function (coverage, sourceMap) {
-  var start = null
-  var end = null
-  var line = null
-
   var b = {}
   var branchMap = {}
   var index = 1
 
   Object.keys(coverage.branchMap).forEach(function (k) {
-    line = sourceMap.originalPositionFor({line: coverage.branchMap[k].line, column: null})
-    if (line.line) {
-      b[index + ''] = []
+    var item = coverage.branchMap[k]
+    var locations = []
+
+    item.locations.every(function (location) {
+      var mapped = mapLocation(sourceMap, location)
+      if (mapped) {
+        locations.push(mapped)
+        return true
+      }
+    })
+
+    if (locations.length > 0) {
+      b[index + ''] = coverage.b[k].slice()
       branchMap[index + ''] = {
-        line: line.line,
-        type: coverage.branchMap[k].type,
-        locations: []
+        line: locations[0].start.line,
+        type: item.type,
+        locations: locations
       }
-      for (var i = 0, location; (location = coverage.branchMap[k].locations[i]) !== undefined; i++) {
-        start = sourceMap.originalPositionFor({line: location.start.line, column: location.start.column})
-        end = sourceMap.originalPositionFor({line: location.end.line, column: location.end.column})
-        if (start.line && end.line) {
-          b[index + ''].push(coverage.b[k][i])
-          branchMap[index + ''].locations.push({
-            start: {source: location.source, line: start.line, column: start.column},
-            end: {source: location.source, line: end.line, column: end.column}
-          })
-        }
-      }
+
       index++
     }
   })

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "forking-tap": "^0.1.1",
     "sanitize-filename": "^1.5.3",
     "sinon": "^1.15.3",
-    "source-map-fixtures": "^0.2.0",
+    "source-map-fixtures": "^0.4.0",
     "source-map-support": "^0.4.0",
     "standard": "^5.2.1",
     "tap": "^1.3.4",

--- a/test/fixtures/_generateCoverage.js
+++ b/test/fixtures/_generateCoverage.js
@@ -16,6 +16,7 @@ var NYC = require('../../')
 var fixtures = {
   bundle: sourceMapFixtures.inline('bundle'),
   inline: sourceMapFixtures.inline('branching'),
+  istanbulIgnore: sourceMapFixtures.inline('istanbul-ignore'),
   none: sourceMapFixtures.none('branching')
 }
 
@@ -30,7 +31,8 @@ nyc.exclude = []
 // Require the fixture so nyc can instrument it, then run it so there's code
 // coverage.
 fixtures.bundle.require().branching()
-fixtures.inline.require().run()
+fixtures.inline.require().run(42)
+fixtures.istanbulIgnore.require().run(99)
 fixtures.none.require().run()
 
 // Copy NYC#writeCoverageFile() behavior to get the coverage object, before
@@ -43,8 +45,8 @@ if (!coverage) {
 }
 
 var reports = _.values(coverage)
-if (reports.length !== 3) {
-  console.error('Expected 3 reports to be generated, got ' + reports.length)
+if (reports.length !== 4) {
+  console.error('Expected 4 reports to be generated, got ' + reports.length)
   process.exit(1)
 }
 

--- a/test/fixtures/coverage.js
+++ b/test/fixtures/coverage.js
@@ -8,14 +8,22 @@ exports["./node_modules/source-map-fixtures/fixtures/bundle-inline.js"] = {
     "4": 1,
     "5": 0,
     "6": 1,
-    "7": 1,
+    "7": 0,
     "8": 0,
     "9": 1,
     "10": 1,
-    "11": 1
+    "11": 0,
+    "12": 1,
+    "13": 1,
+    "14": 1,
+    "15": 1
   },
   "b": {
     "1": [
+      0,
+      0
+    ],
+    "2": [
       0,
       1
     ]
@@ -23,7 +31,8 @@ exports["./node_modules/source-map-fixtures/fixtures/bundle-inline.js"] = {
   "f": {
     "1": 0,
     "2": 0,
-    "3": 1
+    "3": 0,
+    "4": 1
   },
   "fnMap": {
     "1": {
@@ -60,10 +69,24 @@ exports["./node_modules/source-map-fixtures/fixtures/bundle-inline.js"] = {
       "loc": {
         "start": {
           "line": 14,
-          "column": 8
+          "column": 10
         },
         "end": {
           "line": 14,
+          "column": 23
+        }
+      }
+    },
+    "4": {
+      "name": "(anonymous_4)",
+      "line": 21,
+      "loc": {
+        "start": {
+          "line": 21,
+          "column": 8
+        },
+        "end": {
+          "line": 21,
           "column": 21
         }
       }
@@ -126,83 +149,151 @@ exports["./node_modules/source-map-fixtures/fixtures/bundle-inline.js"] = {
         "column": 0
       },
       "end": {
-        "line": 18,
+        "line": 19,
         "column": 2
       }
     },
     "7": {
       "start": {
-        "line": 15,
+        "line": 16,
         "column": 2
       },
       "end": {
-        "line": 17,
+        "line": 18,
         "column": 3
       }
     },
     "8": {
       "start": {
-        "line": 16,
+        "line": 17,
         "column": 4
       },
       "end": {
-        "line": 16,
+        "line": 17,
         "column": 16
-      }
+      },
+      "skip": true
     },
     "9": {
       "start": {
-        "line": 20,
+        "line": 21,
         "column": 0
       },
       "end": {
-        "line": 20,
-        "column": 22
+        "line": 25,
+        "column": 2
       }
     },
     "10": {
       "start": {
-        "line": 21,
-        "column": 0
+        "line": 22,
+        "column": 2
       },
       "end": {
-        "line": 21,
-        "column": 19
+        "line": 24,
+        "column": 3
       }
     },
     "11": {
       "start": {
-        "line": 22,
+        "line": 23,
+        "column": 4
+      },
+      "end": {
+        "line": 23,
+        "column": 16
+      }
+    },
+    "12": {
+      "start": {
+        "line": 27,
         "column": 0
       },
       "end": {
-        "line": 22,
+        "line": 27,
+        "column": 22
+      }
+    },
+    "13": {
+      "start": {
+        "line": 28,
+        "column": 0
+      },
+      "end": {
+        "line": 28,
+        "column": 29
+      }
+    },
+    "14": {
+      "start": {
+        "line": 29,
+        "column": 0
+      },
+      "end": {
+        "line": 29,
+        "column": 19
+      }
+    },
+    "15": {
+      "start": {
+        "line": 30,
+        "column": 0
+      },
+      "end": {
+        "line": 30,
         "column": 19
       }
     }
   },
   "branchMap": {
     "1": {
-      "line": 15,
+      "line": 16,
       "type": "if",
       "locations": [
         {
           "start": {
-            "line": 15,
+            "line": 16,
             "column": 2
           },
           "end": {
-            "line": 15,
+            "line": 16,
+            "column": 2
+          },
+          "skip": true
+        },
+        {
+          "start": {
+            "line": 16,
+            "column": 2
+          },
+          "end": {
+            "line": 16,
+            "column": 2
+          }
+        }
+      ]
+    },
+    "2": {
+      "line": 22,
+      "type": "if",
+      "locations": [
+        {
+          "start": {
+            "line": 22,
+            "column": 2
+          },
+          "end": {
+            "line": 22,
             "column": 2
           }
         },
         {
           "start": {
-            "line": 15,
+            "line": 22,
             "column": 2
           },
           "end": {
-            "line": 15,
+            "line": 22,
             "column": 2
           }
         }
@@ -216,13 +307,13 @@ exports["./node_modules/source-map-fixtures/fixtures/branching-inline.js"] = {
     "1": 1,
     "2": 1,
     "3": 1,
-    "4": 0,
+    "4": 1,
     "5": 1
   },
   "b": {
     "1": [
-      0,
-      1
+      1,
+      0
     ]
   },
   "f": {
@@ -318,6 +409,123 @@ exports["./node_modules/source-map-fixtures/fixtures/branching-inline.js"] = {
           },
           "end": {
             "line": 7,
+            "column": 2
+          }
+        }
+      ]
+    }
+  }
+}
+exports["./node_modules/source-map-fixtures/fixtures/istanbul-ignore-inline.js"] = {
+  "path": "./node_modules/source-map-fixtures/fixtures/istanbul-ignore-inline.js",
+  "s": {
+    "1": 1,
+    "2": 1,
+    "3": 1,
+    "4": 0,
+    "5": 1
+  },
+  "b": {
+    "1": [
+      0,
+      1
+    ]
+  },
+  "f": {
+    "1": 1
+  },
+  "fnMap": {
+    "1": {
+      "name": "(anonymous_1)",
+      "line": 6,
+      "loc": {
+        "start": {
+          "line": 6,
+          "column": 8
+        },
+        "end": {
+          "line": 6,
+          "column": 21
+        }
+      }
+    }
+  },
+  "statementMap": {
+    "1": {
+      "start": {
+        "line": 3,
+        "column": 0
+      },
+      "end": {
+        "line": 5,
+        "column": 3
+      }
+    },
+    "2": {
+      "start": {
+        "line": 6,
+        "column": 0
+      },
+      "end": {
+        "line": 11,
+        "column": 2
+      }
+    },
+    "3": {
+      "start": {
+        "line": 8,
+        "column": 2
+      },
+      "end": {
+        "line": 10,
+        "column": 3
+      }
+    },
+    "4": {
+      "start": {
+        "line": 9,
+        "column": 4
+      },
+      "end": {
+        "line": 9,
+        "column": 16
+      },
+      "skip": true
+    },
+    "5": {
+      "start": {
+        "line": 12,
+        "column": 0
+      },
+      "end": {
+        "line": 12,
+        "column": 16
+      }
+    }
+  },
+  "branchMap": {
+    "1": {
+      "line": 8,
+      "type": "if",
+      "locations": [
+        {
+          "start": {
+            "line": 8,
+            "column": 2
+          },
+          "end": {
+            "line": 8,
+            "column": 2
+          },
+          "skip": true
+        },
+        {
+          "start": {
+            "line": 8,
+            "column": 2
+          },
+          "end": {
+            "line": 8,
             "column": 2
           }
         }

--- a/test/src/source-map-cache.js
+++ b/test/src/source-map-cache.js
@@ -9,6 +9,7 @@ var sourceMapFixtures = require('source-map-fixtures')
 var covered = _.mapValues({
   bundle: sourceMapFixtures.inline('bundle'),
   inline: sourceMapFixtures.inline('branching'),
+  istanbulIgnore: sourceMapFixtures.inline('istanbul-ignore'),
   none: sourceMapFixtures.none('branching')
 }, function (fixture) {
   return _.assign({
@@ -46,6 +47,11 @@ describe('source-map-cache', function () {
   it('does not rewrite if there is no source map', function () {
     var mappedCoverage = sourceMapCache.applySourceMaps(coverage)
     mappedCoverage[covered.none.relpath].should.eql(coverage[covered.none.relpath])
+  })
+
+  it('retains /* istanbul ignore … */ results', function () {
+    var mappedCoverage = sourceMapCache.applySourceMaps(coverage)
+    mappedCoverage[covered.istanbulIgnore.mappedPath].statementMap['3'].should.have.property('skip', true)
   })
 
   describe('path', function () {


### PR DESCRIPTION
remap-istanbul's mapping function seems to cover more edge cases, as well as preserving "skip" annotations. This commit rewrites nyc's mapping logic to use a helper function adapted from remap-istanbul. See <https://github.com/SitePen/remap-istanbul/blob/30b67ad3f24ba7e0da8b8888d5a7c3c8480d48b2/lib/remap.js#L55:L108>
for the original.

Fixes #67.

@bcoe `remap-istanbul` is [BSD licensed](https://github.com/SitePen/remap-istanbul/blob/30b67ad3f24ba7e0da8b8888d5a7c3c8480d48b2/LICENSE). Not quite sure what attribution is required in the source code for copying their function.

It's possible that including the ["skip" annotation](https://github.com/SitePen/remap-istanbul/blob/30b67ad3f24ba7e0da8b8888d5a7c3c8480d48b2/lib/remap.js#L105) in nyc's existing logic is sufficient. Here's where I have to confess I have no clue how the source map format actually works :wink:

Regardless it seems like `remap-istanbul`'s logic is stronger (though in other places overly so). Unfortunately the package as a whole does too much to be hooked into nyc, and the remapping logic is tightly coupled with retrieving source maps so it can't be used directly.