### PR TITLE
Fix ability to self-test using `npm link`.

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ var rimraf = require('rimraf')
 var onExit = require('signal-exit')
 var stripBom = require('strip-bom')
 var SourceMapCache = require('./lib/source-map-cache')
+var resolveFrom = require('resolve-from')
 
 /* istanbul ignore next */
 if (/index\.covered\.js$/.test(__filename)) {
@@ -54,14 +55,15 @@ function NYC (opts) {
 NYC.prototype._loadAdditionalModules = function () {
   var _this = this
   this.require.forEach(function (r) {
-    try {
-      // first attempt to require the module relative to
-      // the directory being instrumented.
-      require(path.resolve(_this.cwd, './node_modules', r))
-    } catch (e) {
-      // now try other locations, .e.g, the nyc node_modules folder.
-      require(r)
+    // first attempt to require the module relative to
+    // the directory being instrumented.
+    var p = resolveFrom(_this.cwd, r)
+    if (p) {
+      require(p)
+      return
     }
+    // now try other locations, .e.g, the nyc node_modules folder.
+    require(r)
   })
 }
 

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "lodash": "^3.10.0",
     "micromatch": "~2.1.6",
     "mkdirp": "^0.5.0",
+    "resolve-from": "^2.0.0",
     "rimraf": "^2.4.2",
     "signal-exit": "^2.1.1",
     "source-map": "^0.5.3",


### PR DESCRIPTION
We had two problems. 

1. Our attempt to resolve the module passed to the `--require` 
flag was grabbing from `nyc/node_modules. A switch to `require-from` solved that.

2. We were collecting source-map information from every file required. This
caused bad things to happen when convert-source-map saw it's source-map-comment
regular expression and thought it was an actual source map comment. Only
collecting source map information when needed made things run faster and 
fixed the problem