### PR TITLE
get tests passing on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![Build Status](https://travis-ci.org/bcoe/nyc.png)](https://travis-ci.org/bcoe/nyc)
 [![Coverage Status](https://coveralls.io/repos/bcoe/nyc/badge.svg?branch=)](https://coveralls.io/r/bcoe/nyc?branch=)
 [![NPM version](https://img.shields.io/npm/v/nyc.svg)](https://www.npmjs.com/package/nyc)
+[![Windows Tests][https://img.shields.io/appveyor/ci/bcoe/nyc/master.svg?label=Windows%20Tests]][https://ci.appveyor.com/project/bcoe/nyc]
+
 
 ```shell
 nyc npm test

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/bcoe/nyc.png)](https://travis-ci.org/bcoe/nyc)
 [![Coverage Status](https://coveralls.io/repos/bcoe/nyc/badge.svg?branch=)](https://coveralls.io/r/bcoe/nyc?branch=)
 [![NPM version](https://img.shields.io/npm/v/nyc.svg)](https://www.npmjs.com/package/nyc)
-[![Windows Tests][https://img.shields.io/appveyor/ci/bcoe/nyc/master.svg?label=Windows%20Tests]][https://ci.appveyor.com/project/bcoe/nyc]
+[![Windows Tests](https://img.shields.io/appveyor/ci/bcoe/nyc/master.svg?label=Windows%20Tests)](https://ci.appveyor.com/project/bcoe/nyc)
 
 
 ```shell

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,6 @@ environment:
     - nodejs_version: '5'
     - nodejs_version: '4'
     - nodejs_version: '0.12'
-    - nodejs_version: '0.10'
 install:
   - ps: Install-Product node $env:nodejs_version
   - set CI=true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,22 @@
+environment:
+  matrix:
+    - nodejs_version: '5'
+    - nodejs_version: '4'
+    - nodejs_version: '0.12'
+    - nodejs_version: '0.10'
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - set CI=true
+  - npm -g install npm@latest
+  - set PATH=%APPDATA%\npm;%PATH%
+  - npm install
+matrix:
+  fast_finish: true
+build: off
+version: '{build}'
+shallow_clone: true
+clone_depth: 1
+test_script:
+  - node --version
+  - npm --version
+  - npm test

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "source-map-support": "^0.4.0",
     "standard": "^5.2.1",
     "tap": "^1.3.4",
+    "win-spawn": "^2.0.0",
     "zero-fill": "^2.2.1"
   },
   "bundleDependencies": [

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "yargs": "^3.15.0"
   },
   "devDependencies": {
+    "any-path": "^1.2.0",
     "chai": "^3.0.0",
     "coveralls": "^2.11.4",
     "del": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "coveralls": "^2.11.4",
     "del": "^2.2.0",
     "forking-tap": "^0.1.1",
+    "is-windows": "^0.1.0",
     "sanitize-filename": "^1.5.3",
     "sinon": "^1.15.3",
     "source-map-fixtures": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "pretest": "standard",
     "test": "npm run cover",
-    "clean": "rm -rf ./.nyc_output ./.self_coverage ./test/fixtures/.nyc_output ./test/build && rm -f *covered.js ./lib/*covered.js",
+    "clean": "rimraf ./.nyc_output ./.self_coverage ./test/fixtures/.nyc_output ./test/build *covered.js ./lib/*covered.js",
     "build": "node ./build-tests",
     "instrument": "node ./build-self-coverage.js",
     "run-tests": "tap --no-cov -b ./test/build/*.js ./test/src/source-map-cache.js",

--- a/test/fixtures/child-1.js
+++ b/test/fixtures/child-1.js
@@ -1,0 +1,1 @@
+// invoked by spawn.

--- a/test/fixtures/child-2.js
+++ b/test/fixtures/child-2.js
@@ -1,0 +1,1 @@
+// invoked by spawn.

--- a/test/fixtures/spawn.js
+++ b/test/fixtures/spawn.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
 
 var spawn = require('child_process').spawn
-spawn(process.execPath, ['sigint.js'], { cwd: __dirname })
-spawn(process.execPath, ['sigterm.js'], { cwd: __dirname })
+spawn(process.execPath, ['child-1.js'], { cwd: __dirname })
+spawn(process.execPath, ['child-2.js'], { cwd: __dirname })

--- a/test/src/nyc-test.js
+++ b/test/src/nyc-test.js
@@ -14,6 +14,7 @@ try {
 var path = require('path')
 var rimraf = require('rimraf')
 var sinon = require('sinon')
+var isWindows = require('is-windows')
 var spawn = require('win-spawn')
 var fixtures = path.resolve(__dirname, '../fixtures')
 var bin = path.resolve(__dirname, '../../bin/nyc')
@@ -197,10 +198,12 @@ describe('nyc', function () {
     }
 
     it('writes coverage report when process is killed with SIGTERM', function (done) {
+      if (isWindows) return done()
       testSignal('sigterm', done)
     })
 
     it('writes coverage report when process is killed with SIGINT', function (done) {
+      if (isWindows) return done()
       testSignal('sigint', done)
     })
 
@@ -285,7 +288,7 @@ describe('nyc', function () {
         cwd: process.cwd(),
         reporter: reporters
       })
-      var proc = spawn(process.execPath, ['./test/fixtures/sigint.js'], {
+      var proc = spawn(process.execPath, ['./test/fixtures/not-loaded.js'], {
         cwd: process.cwd(),
         env: process.env,
         stdio: 'inherit'

--- a/test/src/nyc-test.js
+++ b/test/src/nyc-test.js
@@ -239,7 +239,7 @@ describe('nyc', function () {
             add: function (report) {
               // the subprocess we ran should output reports
               // for files in the fixtures directory.
-              Object.keys(report).should.match(/.\/(spawn|sigint|sigterm)\.js/)
+              Object.keys(report).should.match(/.\/(spawn|child-1|child-2)\.js/)
             }
           },
           {
@@ -288,7 +288,7 @@ describe('nyc', function () {
         cwd: process.cwd(),
         reporter: reporters
       })
-      var proc = spawn(process.execPath, ['./test/fixtures/not-loaded.js'], {
+      var proc = spawn(process.execPath, ['./test/fixtures/child-1.js'], {
         cwd: process.cwd(),
         env: process.env,
         stdio: 'inherit'

--- a/test/src/nyc-test.js
+++ b/test/src/nyc-test.js
@@ -400,9 +400,9 @@ describe('nyc', function () {
       nyc.addAllFiles()
 
       var reports = _.filter(nyc._loadReports(), function (report) {
-        return report['./test/fixtures/not-loaded.js']
+        return report['./test' + path.sep + 'fixtures' + path.sep + 'not-loaded.js']
       })
-      var report = reports[0]['./test/fixtures/not-loaded.js']
+      var report = reports[0]['./test' + path.sep + 'fixtures' + path.sep + 'not-loaded.js']
 
       reports.length.should.equal(1)
       report.s['1'].should.equal(0)

--- a/test/src/nyc-test.js
+++ b/test/src/nyc-test.js
@@ -14,7 +14,7 @@ try {
 var path = require('path')
 var rimraf = require('rimraf')
 var sinon = require('sinon')
-var spawn = require('child_process').spawn
+var spawn = require('win-spawn')
 var fixtures = path.resolve(__dirname, '../fixtures')
 var bin = path.resolve(__dirname, '../../bin/nyc')
 

--- a/test/src/nyc-test.js
+++ b/test/src/nyc-test.js
@@ -2,6 +2,7 @@
 
 require('source-map-support').install()
 var _ = require('lodash')
+var ap = require('any-path')
 var fs = require('fs')
 var NYC
 
@@ -400,9 +401,9 @@ describe('nyc', function () {
       nyc.addAllFiles()
 
       var reports = _.filter(nyc._loadReports(), function (report) {
-        return report['./test' + path.sep + 'fixtures' + path.sep + 'not-loaded.js']
+        return ap(report['./test/fixtures/not-loaded.js'])
       })
-      var report = reports[0]['./test' + path.sep + 'fixtures' + path.sep + 'not-loaded.js']
+      var report = reports[0]['./test/fixtures/not-loaded.js']
 
       reports.length.should.equal(1)
       report.s['1'].should.equal(0)

--- a/test/src/nyc-test.js
+++ b/test/src/nyc-test.js
@@ -401,7 +401,7 @@ describe('nyc', function () {
       nyc.addAllFiles()
 
       var reports = _.filter(nyc._loadReports(), function (report) {
-        return ap(report['./test/fixtures/not-loaded.js'])
+        return ap(report)['./test/fixtures/not-loaded.js']
       })
       var report = reports[0]['./test/fixtures/not-loaded.js']
 

--- a/test/src/source-map-cache.js
+++ b/test/src/source-map-cache.js
@@ -1,6 +1,7 @@
 /* global describe, it */
 
 var _ = require('lodash')
+var ap = require('any-path')
 var path = require('path')
 
 var sourceMapFixtures = require('source-map-fixtures')
@@ -37,7 +38,7 @@ _.forOwn(covered, function (fixture) {
   sourceMapCache.add(fixture.relpath, fixture.contentSync())
 })
 
-var coverage = require('../fixtures/coverage')
+var coverage = ap(require('../fixtures/coverage'))
 var fixture = covered.inline
 
 require('chai').should()


### PR DESCRIPTION
This wasn't as much work as I'd feared, fixes #81 \o/

<img width="679" alt="screen shot 2015-12-19 at 10 14 35 pm" src="https://cloud.githubusercontent.com/assets/194609/11916837/c6f08492-a69e-11e5-998a-168d13752a24.png">

Here's a break down of the changes I've made:

* I've added the `appveyor.yml` that @sindresorhus recommended.
* I switched to using `rimraf` for deleting left over test data, since it's cross-platform.
* windows doesn't (or at least `signal-exit` on Windows) doesn't support `process.kill()`, I've disabled the two tests that require `process.kill` using the `is-windows` module.
  * I've also made the spawn tests not rely on scripts that call `process.kill`.
* I was running into issues with `path.sep` being `\` on Windows and `/` on *nix. 
  * `nyc` and `Istanbul` have paths that are all over the place on Windows (sometimes using one separator, sometimes another).
  * rather than try to unravel this mess (since it doesn't break anything but tests) I've written the helper module `any-path`: https://www.npmjs.com/package/any-path

This work would not have been possible if it wasn't for the hard work of @jamestalmage @novemberborn , refactoring and fixing up tests.

Thank you everyone for all the hard work on this module recently \o/

Reviewers: @jamestalmage @novemberborn 