### PR TITLE
Use find-cache-dir to determine cache directory.

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "arrify": "^1.0.1",
     "caching-transform": "^1.0.0",
     "convert-source-map": "^1.1.2",
+    "find-cache-dir": "^0.1.1",
     "foreground-child": "^1.3.0",
     "glob": "^6.0.2",
     "istanbul": "^0.4.1",


### PR DESCRIPTION
Uses `find-cache-dir` for consistent cache locating with other modules (currently that list only includes AVA, but one can hope). It takes the extra step of ensuring a `package.json` file exists (and hunting up the directory tree for it), otherwise it returns null. If it can't find a suitable cache directory, caching is disabled.

I also dropped the `cacheDirectory()` method in favor of just setting a property.