### PR TITLE
Upgrade foreground-child, remove unnecessary arg munging

### DIFF
--- a/bin/nyc.js
+++ b/bin/nyc.js
@@ -122,11 +122,14 @@ if (process.env.NYC_CWD) {
     if (argv.all) nyc.addAllFiles()
     if (!Array.isArray(argv.require)) argv.require = [argv.require]
 
-    sw([__filename], {
+    var env = {
       NYC_CWD: process.cwd(),
-      NYC_REQUIRE: argv.require.join(','),
       NYC_CACHE: argv.cache ? 'enable' : 'disable'
-    })
+    }
+    if (argv.require.length) {
+      env.NYC_REQUIRE = argv.require.join(',')
+    }
+    sw([__filename], env)
 
     foreground(nyc.mungeArgs(argv), function (done) {
       if (!argv.silent) report(argv)

--- a/index.js
+++ b/index.js
@@ -341,15 +341,6 @@ NYC.prototype.cacheDirectory = function () {
 NYC.prototype.mungeArgs = function (yargv) {
   var argv = process.argv.slice(1)
   argv = argv.slice(argv.indexOf(yargv._[0]))
-  if (!/^(node|iojs)$/.test(argv[0]) &&
-      process.platform === 'win32' &&
-      (/\.js$/.test(argv[0]) ||
-        (!/\.(cmd|exe)$/.test(argv[0]) &&
-        !fs.existsSync(argv[0] + '.cmd') &&
-        !fs.existsSync(argv[0] + '.exe')))) {
-    argv.unshift(process.execPath)
-  }
-
   return argv
 }
 

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "arrify": "^1.0.1",
     "caching-transform": "^1.0.0",
     "convert-source-map": "^1.1.2",
-    "foreground-child": "^1.3.0",
+    "foreground-child": "^1.3.3",
     "glob": "^6.0.2",
     "istanbul": "^0.4.1",
     "md5-hex": "^1.2.0",
@@ -96,7 +96,6 @@
     "split-lines": "^1.0.0",
     "standard": "^5.2.1",
     "tap": "^2.3.4",
-    "win-spawn": "^2.0.0",
     "zero-fill": "^2.2.1"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "rimraf": "^2.5.0",
     "signal-exit": "^2.1.1",
     "source-map": "^0.5.3",
-    "spawn-wrap": "^1.1.0",
+    "spawn-wrap": "^1.1.1",
     "strip-bom": "^2.0.0",
     "yargs": "^3.15.0"
   },

--- a/test/fixtures/cache-collision-runner.js
+++ b/test/fixtures/cache-collision-runner.js
@@ -3,7 +3,7 @@ var path = require('path')
 
 var assert = require('assert')
 
-var spawn = require('win-spawn')
+var spawn = require('child_process').spawn
 
 var time = process.hrtime()
 

--- a/test/src/nyc-test.js
+++ b/test/src/nyc-test.js
@@ -25,7 +25,7 @@ var path = require('path')
 var rimraf = require('rimraf')
 var sinon = require('sinon')
 var isWindows = require('is-windows')()
-var spawn = require('win-spawn')
+var spawn = require('child_process').spawn
 var fixtures = path.resolve(__dirname, '../fixtures')
 var projectDir = path.resolve(__dirname, '../..')
 var projectTempDir = path.join(projectDir, '.nyc_output')
@@ -468,8 +468,7 @@ describe('nyc', function () {
       var nyc = new NYC({cwd: fixtures})
       nyc.clearCache()
 
-      var args = isWindows ? [bin] : [bin, process.execPath]
-      args = args.concat(['./cache-collision-runner.js'])
+      var args = [bin, process.execPath, './cache-collision-runner.js']
 
       var proc = spawn(process.execPath, args, {
         cwd: fixtures,


### PR DESCRIPTION
Foreground-child is now using cross-spawn-async in order to be able to
properly spawn shebangs and .cmd/.exe files.  This avoids the extra
cmd.exe that win-spawn throws into the mix, since that causes problems
when there is no PATH environ and a binary is being called explicitly
via a full path name.

Cross-spawn-async is a lot more code than win-spawn, but the approach it
takes is more surgical and well-tested.

Because of this, it's no longer necessary to unshift the node/io.js
binary onto the argument list when spawning a shebanged javascript file.
So, doing 'nyc mocha ...' on Windows will now work, and it's no longer
necessary to do 'nyc ./node_modules/mocha/bin/mocha.js ...' or any other
extra manual path munging.