### PR TITLE
Use `nyc` instead of `config.nyc` in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ nyc report --reporter=lcov
 ## Excluding Files
 
 You can tell nyc to exclude specific files and directories by adding
-an `config.nyc.exclude` array to your `package.json`. Each element of
+an `nyc.exclude` array to your `package.json`. Each element of
 the array is a glob pattern indicating which paths should be omitted.
 
 Globs are matched using [micromatch](https://www.npmjs.com/package/micromatch)
@@ -90,19 +90,18 @@ Globs are matched using [micromatch](https://www.npmjs.com/package/micromatch)
 In addition to patterns specified in the package, nyc will always exclude
 files in `node_modules`.
 
-For example, the following config will exclude all `node_modules`,
+For example, the following config will exclude everything in `node_modules`,
 any files with the extension `.spec.js`, and anything in the `build`
 directory:
 
 ```json
-{"config": {
-  "nyc": {
-    "exclude": [
+{"nyc": {
+  "exclude": [
       "**/*.spec.js",
       "build"
     ]
   }
-}}
+}
 ```
 
 > Note: exclude defaults to `['test', 'test{,-*}.js']`, which would exclude

--- a/package.json
+++ b/package.json
@@ -23,20 +23,18 @@
     "lib/*.js",
     "!**/*covered.js"
   ],
-  "config": {
-    "nyc": {
-      "exclude": [
-        "node_modules",
-        "bin",
-        "coverage",
-        "test/fixtures/coverage.js",
-        "test/build/*",
-        "test/nyc-test.js",
-        "test/source-map-cache.js",
-        "index.covered.js",
-        "test/fixtures/_generateCoverage.js"
-      ]
-    }
+  "nyc": {
+    "exclude": [
+      "node_modules",
+      "bin",
+      "coverage",
+      "test/fixtures/coverage.js",
+      "test/build/*",
+      "test/nyc-test.js",
+      "test/source-map-cache.js",
+      "index.covered.js",
+      "test/fixtures/_generateCoverage.js"
+    ]
   },
   "standard": {
     "ignore": [
@@ -74,6 +72,8 @@
     "md5-hex": "^1.2.0",
     "micromatch": "~2.1.6",
     "mkdirp": "^0.5.0",
+    "pkg-up": "^1.0.0",
+    "read-pkg": "^1.1.0",
     "resolve-from": "^2.0.0",
     "rimraf": "^2.5.0",
     "signal-exit": "^2.1.1",

--- a/test/src/nyc-test.js
+++ b/test/src/nyc-test.js
@@ -59,15 +59,28 @@ describe('nyc', function () {
 
       nyc.cwd.should.equal(path.resolve(__dirname, '../fixtures'))
     })
+
+    it('will look upwards for package.json from cwd', function () {
+      var nyc = new NYC({cwd: __dirname})
+      nyc.cwd.should.eql(path.join(__dirname, '../..'))
+    })
   })
 
   describe('config', function () {
-    it("loads 'exclude' patterns from package.json", function () {
+    it("loads 'exclude' patterns from package.json#config.nyc", function () {
       var nyc = new NYC({
         cwd: path.resolve(__dirname, '../fixtures')
       })
 
       nyc.exclude.length.should.eql(5)
+    })
+
+    it("loads 'exclude' patterns from package.json#nyc", function () {
+      var nyc = new NYC({
+        cwd: path.resolve(__dirname, '../..')
+      })
+
+      nyc.exclude.length.should.eql(19)
     })
   })
 


### PR DESCRIPTION
Fixes #131

This also uses `pkg-up` to locate the nearest `package.json` from `cwd`, and will move `cwd` to there. This allows you to invoke `nyc` from a subdirectory of your project and still have it behave as expected.  This is something our caching mechanism already does. If it can't find a `package.json`, it just uses the original `cwd` option.