### PR TITLE
Don't try to cover the bin/nyc.js file

### DIFF
--- a/bin/nyc.js
+++ b/bin/nyc.js
@@ -10,7 +10,7 @@ try {
 var path = require('path')
 var sw = require('spawn-wrap')
 
-if (process.env.NYC_CWD) {
+if (process.env.NYC_CWD && process.argv[2] !== __filename) {
   ;(new NYC({
     require: process.env.NYC_REQUIRE ? process.env.NYC_REQUIRE.split(',') : [],
     enableCache: process.env.NYC_CACHE === 'enable'

--- a/bin/nyc.js
+++ b/bin/nyc.js
@@ -110,12 +110,12 @@ var yargs = require('yargs')
   .epilog('visit http://git.io/vTJJB for list of available reporters')
 var argv = yargs.argv
 
-if (~argv._.indexOf('report')) {
+if (argv._[0] === 'report') {
   // run a report.
   process.env.NYC_CWD = process.cwd()
 
   report(argv)
-} else if (~argv._.indexOf('check-coverage')) {
+} else if (argv._[0] === 'check-coverage') {
   checkCoverage(argv)
 } else if (argv._.length) {
   // wrap subprocesses and execute argv[1]

--- a/bin/nyc.js
+++ b/bin/nyc.js
@@ -9,153 +9,145 @@ try {
 
 var path = require('path')
 var sw = require('spawn-wrap')
+var wrapper = require.resolve('./wrap.js')
 
-if (process.env.NYC_CWD && process.argv[2] !== __filename) {
-  ;(new NYC({
-    require: process.env.NYC_REQUIRE ? process.env.NYC_REQUIRE.split(',') : [],
-    enableCache: process.env.NYC_CACHE === 'enable'
-  })).wrap()
+var yargs = require('yargs')
+  .usage('$0 [command] [options]\n\nrun your tests with the nyc bin to instrument them with coverage')
+  .command('report', 'run coverage report for .nyc_output', function (yargs) {
+    yargs
+      .usage('$0 report [options]')
+      .option('r', {
+        alias: 'reporter',
+        describe: 'coverage reporter(s) to use',
+        default: 'text'
+      })
+      .help('h')
+      .alias('h', 'help')
+      .example('$0 report --reporter=lcov', 'output an HTML lcov report to ./coverage')
+  })
+  .command('check-coverage', 'check whether coverage is within thresholds provided', function (yargs) {
+    yargs
+      .usage('$0 check-coverage [options]')
+      .option('b', {
+        alias: 'branches',
+        default: 0,
+        description: 'what % of branches must be covered?'
+      })
+      .option('f', {
+        alias: 'functions',
+        default: 0,
+        description: 'what % of functions must be covered?'
+      })
+      .option('l', {
+        alias: 'lines',
+        default: 90,
+        description: 'what % of lines must be covered?'
+      })
+      .option('s', {
+        alias: 'statements',
+        default: 0,
+        description: 'what % of statements must be covered?'
+      })
+      .help('h')
+      .alias('h', 'help')
+      .example('$0 check-coverage --lines 95', "check whether the JSON in nyc's output folder meets the thresholds provided")
+  })
+  .option('r', {
+    alias: 'reporter',
+    describe: 'coverage reporter(s) to use',
+    default: 'text'
+  })
+  .option('s', {
+    alias: 'silent',
+    default: false,
+    type: 'boolean',
+    describe: "don't output a report after tests finish running"
+  })
+  .option('a', {
+    alias: 'all',
+    default: false,
+    type: 'boolean',
+    describe: 'whether or not to instrument all files of the project (not just the ones touched by your test suite)'
+  })
+  .option('i', {
+    alias: 'require',
+    default: [],
+    describe: 'a list of additional modules that nyc should attempt to require in its subprocess, e.g., babel-register, babel-polyfill.'
+  })
+  .option('c', {
+    alias: 'cache',
+    default: false,
+    type: 'boolean',
+    describe: 'cache instrumentation results for improved performance'
+  })
+  .option('check-coverage', {
+    type: 'boolean',
+    default: false,
+    describe: 'check whether coverage is within thresholds provided'
+  })
+  .option('branches', {
+    default: 0,
+    description: 'what % of branches must be covered?'
+  })
+  .option('functions', {
+    default: 0,
+    description: 'what % of functions must be covered?'
+  })
+  .option('lines', {
+    default: 90,
+    description: 'what % of lines must be covered?'
+  })
+  .option('statements', {
+    default: 0,
+    description: 'what % of statements must be covered?'
+  })
+  .help('h')
+  .alias('h', 'help')
+  .version(require('../package.json').version)
+  .example('$0 npm test', 'instrument your tests with coverage')
+  .example('$0 --require babel-core/polyfill --require babel-core/register npm test', 'instrument your tests with coverage and babel')
+  .example('$0 report --reporter=text-lcov', 'output lcov report after running your tests')
+  .epilog('visit http://git.io/vTJJB for list of available reporters')
+var argv = yargs.argv
 
-  sw.runMain()
-} else {
-  var yargs = require('yargs')
-    .usage('$0 [command] [options]\n\nrun your tests with the nyc bin to instrument them with coverage')
-    .command('report', 'run coverage report for .nyc_output', function (yargs) {
-      yargs
-        .usage('$0 report [options]')
-        .option('r', {
-          alias: 'reporter',
-          describe: 'coverage reporter(s) to use',
-          default: 'text'
-        })
-        .help('h')
-        .alias('h', 'help')
-        .example('$0 report --reporter=lcov', 'output an HTML lcov report to ./coverage')
-    })
-    .command('check-coverage', 'check whether coverage is within thresholds provided', function (yargs) {
-      yargs
-        .usage('$0 check-coverage [options]')
-        .option('b', {
-          alias: 'branches',
-          default: 0,
-          description: 'what % of branches must be covered?'
-        })
-        .option('f', {
-          alias: 'functions',
-          default: 0,
-          description: 'what % of functions must be covered?'
-        })
-        .option('l', {
-          alias: 'lines',
-          default: 90,
-          description: 'what % of lines must be covered?'
-        })
-        .option('s', {
-          alias: 'statements',
-          default: 0,
-          description: 'what % of statements must be covered?'
-        })
-        .help('h')
-        .alias('h', 'help')
-        .example('$0 check-coverage --lines 95', "check whether the JSON in nyc's output folder meets the thresholds provided")
-    })
-    .option('r', {
-      alias: 'reporter',
-      describe: 'coverage reporter(s) to use',
-      default: 'text'
-    })
-    .option('s', {
-      alias: 'silent',
-      default: false,
-      type: 'boolean',
-      describe: "don't output a report after tests finish running"
-    })
-    .option('a', {
-      alias: 'all',
-      default: false,
-      type: 'boolean',
-      describe: 'whether or not to instrument all files of the project (not just the ones touched by your test suite)'
-    })
-    .option('i', {
-      alias: 'require',
-      default: [],
-      describe: 'a list of additional modules that nyc should attempt to require in its subprocess, e.g., babel-register, babel-polyfill.'
-    })
-    .option('c', {
-      alias: 'cache',
-      default: false,
-      type: 'boolean',
-      describe: 'cache instrumentation results for improved performance'
-    })
-    .option('check-coverage', {
-      type: 'boolean',
-      default: false,
-      describe: 'check whether coverage is within thresholds provided'
-    })
-    .option('branches', {
-      default: 0,
-      description: 'what % of branches must be covered?'
-    })
-    .option('functions', {
-      default: 0,
-      description: 'what % of functions must be covered?'
-    })
-    .option('lines', {
-      default: 90,
-      description: 'what % of lines must be covered?'
-    })
-    .option('statements', {
-      default: 0,
-      description: 'what % of statements must be covered?'
-    })
-    .help('h')
-    .alias('h', 'help')
-    .version(require('../package.json').version)
-    .example('$0 npm test', 'instrument your tests with coverage')
-    .example('$0 --require babel-core/polyfill --require babel-core/register npm test', 'instrument your tests with coverage and babel')
-    .example('$0 report --reporter=text-lcov', 'output lcov report after running your tests')
-    .epilog('visit http://git.io/vTJJB for list of available reporters')
-  var argv = yargs.argv
+if (~argv._.indexOf('report')) {
+  // run a report.
+  process.env.NYC_CWD = process.cwd()
 
-  if (~argv._.indexOf('report')) {
-    // run a report.
-    process.env.NYC_CWD = process.cwd()
+  report(argv)
+} else if (~argv._.indexOf('check-coverage')) {
+  checkCoverage(argv)
+} else if (argv._.length) {
+  // wrap subprocesses and execute argv[1]
+  var nyc = (new NYC())
+  nyc.reset()
 
-    report(argv)
-  } else if (~argv._.indexOf('check-coverage')) {
-    checkCoverage(argv)
-  } else if (argv._.length) {
-    // wrap subprocesses and execute argv[1]
-    var nyc = (new NYC())
-    nyc.reset()
+  if (argv.all) nyc.addAllFiles()
+  if (!Array.isArray(argv.require)) argv.require = [argv.require]
 
-    if (argv.all) nyc.addAllFiles()
-    if (!Array.isArray(argv.require)) argv.require = [argv.require]
+  var env = {
+    NYC_CWD: process.cwd(),
+    NYC_CACHE: argv.cache ? 'enable' : 'disable'
+  }
+  if (argv.require.length) {
+    env.NYC_REQUIRE = argv.require.join(',')
+  }
+  sw([wrapper], env)
 
-    var env = {
-      NYC_CWD: process.cwd(),
-      NYC_CACHE: argv.cache ? 'enable' : 'disable'
-    }
-    if (argv.require.length) {
-      env.NYC_REQUIRE = argv.require.join(',')
-    }
-    sw([__filename], env)
-
-    foreground(nyc.mungeArgs(argv), function (done) {
-      if (argv.checkCoverage) {
-        checkCoverage(argv, function (done) {
-          if (!argv.silent) report(argv)
-          return done()
-        })
-      } else {
+  foreground(nyc.mungeArgs(argv), function (done) {
+    if (argv.checkCoverage) {
+      checkCoverage(argv, function (done) {
         if (!argv.silent) report(argv)
         return done()
-      }
-    })
-  } else {
-    // I don't have a clue what you're doing.
-    yargs.showHelp()
-  }
+      })
+    } else {
+      if (!argv.silent) report(argv)
+      return done()
+    }
+  })
+} else {
+  // I don't have a clue what you're doing.
+  yargs.showHelp()
 }
 
 function report (argv) {

--- a/bin/wrap.js
+++ b/bin/wrap.js
@@ -1,0 +1,14 @@
+var sw = require('spawn-wrap')
+var NYC
+try {
+  NYC = require('../index.covered.js')
+} catch (e) {
+  NYC = require('../index.js')
+}
+
+;(new NYC({
+  require: process.env.NYC_REQUIRE ? process.env.NYC_REQUIRE.split(',') : [],
+  enableCache: process.env.NYC_CACHE === 'enable'
+})).wrap()
+
+sw.runMain()


### PR DESCRIPTION
This makes it possible to self-test node-tap's coverage reporting and
coverage level checking when running in covered mode.  Otherwise, doing
`node {nycBin} check-coverage` results in executing the nyc executable
script as the main file (or worse, some module named `check-coverage`,
which obviously doesn't exist).