### PR TITLE
guard against illegal positions

### DIFF
--- a/lib/source-map-cache.js
+++ b/lib/source-map-cache.js
@@ -26,12 +26,29 @@ SourceMapCache.prototype.applySourceMaps = function (report) {
   })
 }
 
+// Istanbul occasionally reports invalid positions. Correct them before they're
+// fed to the source-map consumer.
+function clampPosition (pos) {
+  var line = pos.line
+  var column = pos.column
+  return {
+    // According to
+    // <https://github.com/gotwarlost/istanbul/blob/d919f7355027e3c213aa81af5464962d9dc8350b/coverage.json.md#location-objects>
+    // lines start at 1 and columns at 0.
+    line: Math.max(1, line),
+    column: Math.max(0, column)
+  }
+}
+
 // Maps the coverage location based on the source map. Adapted from getMapping()
 // in remap-istanbul:
 // <https://github.com/SitePen/remap-istanbul/blob/30b67ad3f24ba7e0da8b8888d5a7c3c8480d48b2/lib/remap.js#L55:L108>.
 function mapLocation (sourceMap, location) {
-  var start = sourceMap.originalPositionFor(location.start)
-  var end = sourceMap.originalPositionFor(location.end)
+  var clampedStart = clampPosition(location.start)
+  var clampedEnd = clampPosition(location.end)
+
+  var start = sourceMap.originalPositionFor(clampedStart)
+  var end = sourceMap.originalPositionFor(clampedEnd)
 
   /* istanbul ignore if: edge case too hard to test for */
   if (!start || !end) {
@@ -51,8 +68,8 @@ function mapLocation (sourceMap, location) {
 
   if (start.line === end.line && start.column === end.column) {
     end = sourceMap.originalPositionFor({
-      line: location.end.line,
-      column: location.end.column,
+      line: clampedEnd.line,
+      column: clampedEnd.column,
       bias: 2
     })
     end.column = end.column - 1

--- a/test/src/source-map-cache.js
+++ b/test/src/source-map-cache.js
@@ -65,6 +65,19 @@ describe('source-map-cache', function () {
     report[covered.istanbulIgnore.mappedPath].statementMap['3'].should.have.property('skip', true)
   })
 
+  it('does not fail if istanbul returns illegal positions', function () {
+    var report = getReport()
+    sourceMapCache.applySourceMaps(report)
+
+    var busted = getReport()
+    var start = busted[covered.inline.relpath].statementMap['1'].start
+    start.line = 0
+    start.column = -2
+    sourceMapCache.applySourceMaps(busted)
+
+    expect(busted[covered.inline.mappedPath]).to.deep.equal(report[covered.inline.mappedPath])
+  })
+
   describe('path', function () {
     it('does not rewrite path if the source map has more than one source', function () {
       var report = getReport()


### PR DESCRIPTION
Istanbul can sometimes return illegal position values. Clamp them so they can be used by the source map consumer.

See https://github.com/bcoe/nyc/pull/143#issuecomment-173554681 for background.