### PR TITLE
Preserve function skip annotations

### DIFF
--- a/lib/source-map-cache.js
+++ b/lib/source-map-cache.js
@@ -128,13 +128,17 @@ SourceMapCache.prototype._rewriteFunctions = function (fileReport, sourceMap) {
   var index = 1
 
   Object.keys(fileReport.fnMap).forEach(function (k) {
-    var mapped = mapLocation(sourceMap, fileReport.fnMap[k].loc)
+    var item = fileReport.fnMap[k]
+    var mapped = mapLocation(sourceMap, item.loc)
     if (mapped) {
       f[index + ''] = fileReport.f[k]
       fnMap[index + ''] = {
-        name: fileReport.fnMap[k].name,
+        name: item.name,
         line: mapped.start.line,
         loc: mapped
+      }
+      if (item.skip === true) {
+        fnMap[index + ''].skip = true
       }
       index++
     }

--- a/lib/source-map-cache.js
+++ b/lib/source-map-cache.js
@@ -75,7 +75,7 @@ function mapLocation (sourceMap, location) {
     end.column = end.column - 1
   }
 
-  return {
+  var mapped = {
     start: {
       line: start.line,
       column: start.column
@@ -83,9 +83,12 @@ function mapLocation (sourceMap, location) {
     end: {
       line: end.line,
       column: end.column
-    },
-    skip: location.skip
+    }
   }
+  if (location.skip === true) {
+    mapped.skip = true
+  }
+  return mapped
 }
 
 SourceMapCache.prototype._rewritePath = function (report, fileReport, sourceMap) {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "newline-regex": "^0.2.1",
     "sanitize-filename": "^1.5.3",
     "sinon": "^1.15.3",
-    "source-map-fixtures": "^0.4.0",
+    "source-map-fixtures": "^2.1.0",
     "source-map-support": "^0.4.0",
     "split-lines": "^1.0.0",
     "standard": "^5.2.1",

--- a/test/fixtures/_generateReport.js
+++ b/test/fixtures/_generateReport.js
@@ -23,12 +23,17 @@ var fixtures = {
 require('istanbul')
 
 // Inject nyc into this process.
-var nyc = (new NYC({
+var nyc = new NYC({
   cwd: path.join(__dirname, '..', '..')
-})).wrap()
+})
 // Override the exclude option, source-map-fixtures is inside node_modules but
 // should not be excluded when generating the coverage report.
 nyc.exclude = []
+// Monkey-patch _wrapExit(), it shouldn't run when generating the coverage
+// report.
+nyc._wrapExit = function () {}
+// Now wrap the process.
+nyc.wrap()
 
 // Require the fixture so nyc can instrument it, then run it so there's code
 // coverage.
@@ -59,5 +64,5 @@ reports.forEach(function (coverage) {
 })
 out.end()
 out.on('finish', function () {
-  console.log('Written coverage report.')
+  console.log('Wrote coverage report.')
 })

--- a/test/fixtures/_generateReport.js
+++ b/test/fixtures/_generateReport.js
@@ -17,6 +17,7 @@ var fixtures = {
   bundle: sourceMapFixtures.inline('bundle'),
   inline: sourceMapFixtures.inline('branching'),
   istanbulIgnore: sourceMapFixtures.inline('istanbul-ignore'),
+  istanbulIgnoreFn: sourceMapFixtures.inline('istanbul-ignore-fn'),
   none: sourceMapFixtures.none('branching')
 }
 
@@ -40,6 +41,7 @@ nyc.wrap()
 fixtures.bundle.require().branching()
 fixtures.inline.require().run(42)
 fixtures.istanbulIgnore.require().run(99)
+fixtures.istanbulIgnoreFn.require().run(99)
 fixtures.none.require().run()
 
 // Copy NYC#writeCoverageFile() behavior to get the coverage object, before
@@ -52,8 +54,8 @@ if (!coverage) {
 }
 
 var reports = _.values(coverage)
-if (reports.length !== 4) {
-  console.error('Expected 4 reports to be generated, got ' + reports.length)
+if (reports.length !== 5) {
+  console.error('Expected 5 reports to be generated, got ' + reports.length)
   process.exit(1)
 }
 

--- a/test/fixtures/report.js
+++ b/test/fixtures/report.js
@@ -4,13 +4,13 @@ exports["./node_modules/source-map-fixtures/fixtures/bundle-inline.js"] = {
   "s": {
     "1": 1,
     "2": 1,
-    "3": 0,
-    "4": 1,
-    "5": 0,
-    "6": 1,
+    "3": 1,
+    "4": 0,
+    "5": 1,
+    "6": 0,
     "7": 0,
-    "8": 0,
-    "9": 1,
+    "8": 1,
+    "9": 0,
     "10": 1,
     "11": 0,
     "12": 1,
@@ -21,18 +21,18 @@ exports["./node_modules/source-map-fixtures/fixtures/bundle-inline.js"] = {
   "b": {
     "1": [
       0,
-      0
+      1
     ],
     "2": [
       0,
-      1
+      0
     ]
   },
   "f": {
-    "1": 0,
+    "1": 1,
     "2": 0,
     "3": 0,
-    "4": 1
+    "4": 0
   },
   "fnMap": {
     "1": {
@@ -45,49 +45,49 @@ exports["./node_modules/source-map-fixtures/fixtures/bundle-inline.js"] = {
         },
         "end": {
           "line": 6,
-          "column": 20
+          "column": 21
         }
       }
     },
     "2": {
       "name": "(anonymous_2)",
-      "line": 10,
+      "line": 12,
       "loc": {
         "start": {
-          "line": 10,
-          "column": 8
+          "line": 12,
+          "column": 10
         },
         "end": {
-          "line": 10,
-          "column": 20
+          "line": 12,
+          "column": 23
         }
       }
     },
     "3": {
       "name": "(anonymous_3)",
-      "line": 14,
+      "line": 19,
       "loc": {
         "start": {
-          "line": 14,
-          "column": 10
+          "line": 19,
+          "column": 8
         },
         "end": {
-          "line": 14,
-          "column": 23
+          "line": 19,
+          "column": 20
         }
       }
     },
     "4": {
       "name": "(anonymous_4)",
-      "line": 21,
+      "line": 23,
       "loc": {
         "start": {
-          "line": 21,
+          "line": 23,
           "column": 8
         },
         "end": {
-          "line": 21,
-          "column": 21
+          "line": 23,
+          "column": 20
         }
       }
     }
@@ -109,7 +109,7 @@ exports["./node_modules/source-map-fixtures/fixtures/bundle-inline.js"] = {
         "column": 0
       },
       "end": {
-        "line": 8,
+        "line": 10,
         "column": 2
       }
     },
@@ -119,64 +119,74 @@ exports["./node_modules/source-map-fixtures/fixtures/bundle-inline.js"] = {
         "column": 2
       },
       "end": {
-        "line": 7,
-        "column": 51
+        "line": 9,
+        "column": 3
       }
     },
     "4": {
       "start": {
-        "line": 10,
-        "column": 0
+        "line": 8,
+        "column": 4
       },
       "end": {
-        "line": 12,
-        "column": 2
+        "line": 8,
+        "column": 16
       }
     },
     "5": {
       "start": {
-        "line": 11,
-        "column": 2
+        "line": 12,
+        "column": 0
       },
       "end": {
-        "line": 11,
-        "column": 12
+        "line": 17,
+        "column": 2
       }
     },
     "6": {
       "start": {
         "line": 14,
-        "column": 0
+        "column": 2
       },
       "end": {
-        "line": 19,
-        "column": 2
+        "line": 16,
+        "column": 3
       }
     },
     "7": {
       "start": {
-        "line": 16,
-        "column": 2
-      },
-      "end": {
-        "line": 18,
-        "column": 3
-      }
-    },
-    "8": {
-      "start": {
-        "line": 17,
+        "line": 15,
         "column": 4
       },
       "end": {
-        "line": 17,
+        "line": 15,
         "column": 16
       },
       "skip": true
     },
+    "8": {
+      "start": {
+        "line": 19,
+        "column": 0
+      },
+      "end": {
+        "line": 21,
+        "column": 2
+      }
+    },
     "9": {
       "start": {
-        "line": 21,
+        "line": 20,
+        "column": 2
+      },
+      "end": {
+        "line": 20,
+        "column": 12
+      }
+    },
+    "10": {
+      "start": {
+        "line": 23,
         "column": 0
       },
       "end": {
@@ -184,24 +194,14 @@ exports["./node_modules/source-map-fixtures/fixtures/bundle-inline.js"] = {
         "column": 2
       }
     },
-    "10": {
+    "11": {
       "start": {
-        "line": 22,
+        "line": 24,
         "column": 2
       },
       "end": {
         "line": 24,
-        "column": 3
-      }
-    },
-    "11": {
-      "start": {
-        "line": 23,
-        "column": 4
-      },
-      "end": {
-        "line": 23,
-        "column": 16
+        "column": 51
       }
     },
     "12": {
@@ -247,53 +247,53 @@ exports["./node_modules/source-map-fixtures/fixtures/bundle-inline.js"] = {
   },
   "branchMap": {
     "1": {
-      "line": 16,
+      "line": 7,
       "type": "if",
       "locations": [
         {
           "start": {
-            "line": 16,
+            "line": 7,
             "column": 2
           },
           "end": {
-            "line": 16,
+            "line": 7,
             "column": 2
-          },
-          "skip": true
+          }
         },
         {
           "start": {
-            "line": 16,
+            "line": 7,
             "column": 2
           },
           "end": {
-            "line": 16,
+            "line": 7,
             "column": 2
           }
         }
       ]
     },
     "2": {
-      "line": 22,
+      "line": 14,
       "type": "if",
       "locations": [
         {
           "start": {
-            "line": 22,
+            "line": 14,
             "column": 2
           },
           "end": {
-            "line": 22,
+            "line": 14,
             "column": 2
-          }
+          },
+          "skip": true
         },
         {
           "start": {
-            "line": 22,
+            "line": 14,
             "column": 2
           },
           "end": {
-            "line": 22,
+            "line": 14,
             "column": 2
           }
         }
@@ -526,6 +526,149 @@ exports["./node_modules/source-map-fixtures/fixtures/istanbul-ignore-inline.js"]
           },
           "end": {
             "line": 8,
+            "column": 2
+          }
+        }
+      ]
+    }
+  }
+}
+exports["./node_modules/source-map-fixtures/fixtures/istanbul-ignore-fn-inline.js"] = {
+  "path": "./node_modules/source-map-fixtures/fixtures/istanbul-ignore-fn-inline.js",
+  "s": {
+    "1": 1,
+    "2": 1,
+    "3": 1,
+    "4": 0,
+    "5": 1,
+    "6": 1
+  },
+  "b": {
+    "1": [
+      0,
+      1
+    ]
+  },
+  "f": {
+    "1": 1,
+    "2": 0
+  },
+  "fnMap": {
+    "1": {
+      "name": "(anonymous_1)",
+      "line": 6,
+      "loc": {
+        "start": {
+          "line": 6,
+          "column": 8
+        },
+        "end": {
+          "line": 6,
+          "column": 21
+        }
+      }
+    },
+    "2": {
+      "name": "(anonymous_2)",
+      "line": 15,
+      "loc": {
+        "start": {
+          "line": 15,
+          "column": 10
+        },
+        "end": {
+          "line": 15,
+          "column": 22
+        }
+      },
+      "skip": true
+    }
+  },
+  "statementMap": {
+    "1": {
+      "start": {
+        "line": 3,
+        "column": 0
+      },
+      "end": {
+        "line": 5,
+        "column": 3
+      }
+    },
+    "2": {
+      "start": {
+        "line": 6,
+        "column": 0
+      },
+      "end": {
+        "line": 10,
+        "column": 2
+      }
+    },
+    "3": {
+      "start": {
+        "line": 7,
+        "column": 2
+      },
+      "end": {
+        "line": 9,
+        "column": 3
+      }
+    },
+    "4": {
+      "start": {
+        "line": 8,
+        "column": 4
+      },
+      "end": {
+        "line": 8,
+        "column": 17
+      }
+    },
+    "5": {
+      "start": {
+        "line": 11,
+        "column": 0
+      },
+      "end": {
+        "line": 11,
+        "column": 16
+      }
+    },
+    "6": {
+      "start": {
+        "line": 15,
+        "column": 0
+      },
+      "end": {
+        "line": 15,
+        "column": 25
+      },
+      "skip": true
+    }
+  },
+  "branchMap": {
+    "1": {
+      "line": 7,
+      "type": "if",
+      "locations": [
+        {
+          "start": {
+            "line": 7,
+            "column": 2
+          },
+          "end": {
+            "line": 7,
+            "column": 2
+          }
+        },
+        {
+          "start": {
+            "line": 7,
+            "column": 2
+          },
+          "end": {
+            "line": 7,
             "column": 2
           }
         }

--- a/test/src/source-map-cache.js
+++ b/test/src/source-map-cache.js
@@ -13,6 +13,7 @@ var covered = _.mapValues({
   bundle: sourceMapFixtures.inline('bundle'),
   inline: sourceMapFixtures.inline('branching'),
   istanbulIgnore: sourceMapFixtures.inline('istanbul-ignore'),
+  istanbulIgnoreFn: sourceMapFixtures.inline('istanbul-ignore-fn'),
   none: sourceMapFixtures.none('branching')
 }, function (fixture) {
   return _.assign({
@@ -63,6 +64,7 @@ describe('source-map-cache', function () {
     var report = getReport()
     sourceMapCache.applySourceMaps(report)
     report[covered.istanbulIgnore.mappedPath].statementMap['3'].should.have.property('skip', true)
+    report[covered.istanbulIgnoreFn.mappedPath].fnMap['2'].should.have.property('skip', true)
   })
 
   it('does not fail if istanbul returns illegal positions', function () {


### PR DESCRIPTION
Istanbul may mark functions as being skipped. Make sure these annotations are preserved when source maps are applied. Fixes #67.