### PR TITLE
Don't instrument files outside of the current working directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -183,7 +183,7 @@ NYC.prototype.shouldInstrumentFile = function (filename, relFile) {
   // Don't instrument files that are outside of the current working directory.
   if (/^\.\./.test(path.relative(this.cwd, filename))) return false
 
-  relFile = relFile.replace(/^\.\//, '') // remove leading './'.
+  relFile = relFile.replace(/^\.[\\\/]/, '') // remove leading './' or '.\'.
   return (!this.include || micromatch.any(relFile, this.include)) && !micromatch.any(relFile, this.exclude)
 }
 

--- a/test/src/nyc-test.js
+++ b/test/src/nyc-test.js
@@ -126,6 +126,7 @@ describe('nyc', function () {
       shouldInstrumentFile('/cwd/test-foo.js', 'test-foo.js').should.equal(false)
       shouldInstrumentFile('/cwd/lib/test.js', 'lib/test.js').should.equal(true)
       shouldInstrumentFile('/cwd/foo/bar/test.js', './test.js').should.equal(false)
+      shouldInstrumentFile('/cwd/foo/bar/test.js', '.\\test.js').should.equal(false)
     })
 
     it('should exclude appropriately with config.exclude', function () {
@@ -139,6 +140,7 @@ describe('nyc', function () {
       shouldInstrumentFile('blarg/foo.js', 'blarg/foo.js').should.equal(false)
       shouldInstrumentFile('blerg', 'blerg').should.equal(false)
       shouldInstrumentFile('./blerg', './blerg').should.equal(false)
+      shouldInstrumentFile('./blerg', '.\\blerg').should.equal(false)
     })
 
     it('should exclude outside of the current working directory', function () {
@@ -153,6 +155,7 @@ describe('nyc', function () {
         cwd: '/cwd/node_modules/foo/'
       })
       nyc.shouldInstrumentFile('/cwd/node_modules/foo/bar', './bar').should.equal(true)
+      nyc.shouldInstrumentFile('/cwd/node_modules/foo/bar', '.\\bar').should.equal(true)
     })
 
     it('allows files to be explicitly included, rather than excluded', function () {

--- a/test/src/nyc-test.js
+++ b/test/src/nyc-test.js
@@ -132,7 +132,7 @@ describe('nyc', function () {
       })
       var shouldInstrumentFile = nyc.shouldInstrumentFile.bind(nyc)
 
-      // config.excludes: "blarg", "blerg"
+      // fixtures/package.json configures excludes: "blarg", "blerg"
       shouldInstrumentFile('blarg', 'blarg').should.equal(false)
       shouldInstrumentFile('blarg/foo.js', 'blarg/foo.js').should.equal(false)
       shouldInstrumentFile('blerg', 'blerg').should.equal(false)

--- a/test/src/nyc-test.js
+++ b/test/src/nyc-test.js
@@ -139,25 +139,6 @@ describe('nyc', function () {
       shouldInstrumentFile('./blerg', './blerg').should.equal(false)
     })
 
-    it('should handle example symlinked node_module', function () {
-      var nyc = new NYC({
-        cwd: fixtures
-      })
-      var shouldInstrumentFile = nyc.shouldInstrumentFile.bind(nyc)
-
-      var relPath = '../../../nyc/node_modules/glob/glob.js'
-      var fullPath = '/Users/user/nyc/node_modules/glob/glob.js'
-
-      shouldInstrumentFile(fullPath, relPath).should.equal(false)
-
-      // Full path should be excluded (node_modules)
-      shouldInstrumentFile(fullPath, relPath).should.equal(false)
-
-      // Send both relative and absolute path
-      // Results in exclusion (include = false)
-      shouldInstrumentFile(fullPath, relPath).should.equal(false)
-    })
-
     it('allows a file to be included rather than excluded', function () {
       var nyc = new NYC()
 

--- a/test/src/nyc-test.js
+++ b/test/src/nyc-test.js
@@ -139,18 +139,35 @@ describe('nyc', function () {
       shouldInstrumentFile('./blerg', './blerg').should.equal(false)
     })
 
-    it('allows a file to be included rather than excluded', function () {
+    it('allows files to be explicitly included, rather than excluded', function () {
       var nyc = new NYC()
 
-      // Root package contains config.exclude
-      // Restore exclude to default patterns
       nyc.include = nyc._prepGlobPatterns([
-        'test.js'
+        'foo.js'
       ])
 
       var shouldInstrumentFile = nyc.shouldInstrumentFile.bind(nyc)
-      shouldInstrumentFile('test.js', 'test.js').should.equal(true)
+      shouldInstrumentFile('foo.js', 'foo.js').should.equal(true)
       shouldInstrumentFile('index.js', 'index.js').should.equal(false)
+    })
+
+    it('exclude overrides include', function () {
+      var nyc = new NYC()
+
+      nyc.include = nyc._prepGlobPatterns([
+        'foo.js',
+        'test.js'
+      ])
+      // Ensure default exclude patterns apply, which excludes test.js
+      nyc.exclude = nyc._prepGlobPatterns([
+        '**/node_modules/**',
+        'test/**',
+        'test{,-*}.js'
+      ])
+
+      var shouldInstrumentFile = nyc.shouldInstrumentFile.bind(nyc)
+      shouldInstrumentFile('foo.js', 'foo.js').should.equal(true)
+      shouldInstrumentFile('test.js', 'test.js').should.equal(false)
     })
   })
 


### PR DESCRIPTION
Files outside of the current working directory (meaning higher up in the file hierarchy) should not be instrumented.

Fixes #157 where nyc is run from inside a `node_modules` directory.

Fixes #154 where 'npm link' is used to fulfil dependencies.

This removes matching the include/exclude patterns to the absolute filename, the patterns are now applied only to the relative portion within the current working directory.

`addAllFiles()` has been changed to explicitly add files in the current working directory only.

Some other tests related to include/exclude behavior have been cleaned up.

---

Note that I'm not entirely certain `filename` in `shouldInstrumentFile()` is always absolute. Review on that front would be especially appreciated.

This changes the include/exclude matching behavior, but restricting it to the cwd makes more sense to me.