### PR TITLE
Add support for configurable file extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,23 @@ of the pre-transpiled code. You'll have to configure your custom require hook
 to inline the source map in the transpiled code. For Babel that means setting
 the `sourceMaps` option to `inline`.
 
+## Support For Custom File Extensions (.jsx, .es6)
+Supporting file extensions can be configured through either the configuration arguments or with the `nyc` config section in `package.json`.
+
+```shell
+nyc --extension .jsx --extension .es6 npm test
+```
+
+```json
+{"nyc": {
+  "extensions": [
+      ".jsx",
+      ".es6"
+    ]
+  }
+}
+```
+
 ## Checking Coverage
 
 nyc exposes istanbul's check-coverage tool. After running your tests with nyc,

--- a/bin/nyc.js
+++ b/bin/nyc.js
@@ -88,6 +88,11 @@ var yargs = require('yargs')
     type: 'boolean',
     describe: 'cache instrumentation results for improved performance'
   })
+  .options('e', {
+    alias: 'extension',
+    default: [],
+    describe: 'a list of extensions that nyc should handle in addition to .js'
+  })
   .option('check-coverage', {
     type: 'boolean',
     default: false,
@@ -128,6 +133,7 @@ if (argv._[0] === 'report') {
 } else if (argv._.length) {
   // wrap subprocesses and execute argv[1]
   if (!Array.isArray(argv.require)) argv.require = [argv.require]
+  if (!Array.isArray(argv.extension)) argv.extension = [argv.extension]
 
   var nyc = (new NYC({
     require: argv.require
@@ -142,6 +148,9 @@ if (argv._[0] === 'report') {
   }
   if (argv.require.length) {
     env.NYC_REQUIRE = argv.require.join(',')
+  }
+  if (argv.extension.length) {
+    env.NYC_EXTENSION = argv.extension.join(',')
   }
   sw([wrapper], env)
 

--- a/bin/wrap.js
+++ b/bin/wrap.js
@@ -8,6 +8,7 @@ try {
 
 ;(new NYC({
   require: process.env.NYC_REQUIRE ? process.env.NYC_REQUIRE.split(',') : [],
+  extension: process.env.NYC_EXTENSION ? process.env.NYC_EXTENSION.split(',') : [],
   enableCache: process.env.NYC_CACHE === 'enable'
 })).wrap()
 

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ var md5hex = require('md5-hex')
 var findCacheDir = require('find-cache-dir')
 var pkgUp = require('pkg-up')
 var readPkg = require('read-pkg')
+var js = require('default-require-extensions/js')
 
 /* istanbul ignore next */
 if (/index\.covered\.js$/.test(__filename)) {
@@ -53,7 +54,14 @@ function NYC (opts) {
   // require extensions can be provided as config in package.json.
   this.require = arrify(config.require || opts.require)
 
-  this.transform = this._createTransform()
+  this.extensions = arrify(config.extension || opts.extension).concat('.js').map(function (ext) {
+    return ext.toLowerCase()
+  })
+
+  this.transforms = this.extensions.reduce(function (transforms, ext) {
+    transforms[ext] = this._createTransform(ext)
+    return transforms
+  }.bind(this), {})
 
   this.sourceMapCache = new SourceMapCache()
 
@@ -79,7 +87,7 @@ NYC.prototype._loadConfig = function (opts) {
   return config
 }
 
-NYC.prototype._createTransform = function () {
+NYC.prototype._createTransform = function (ext) {
   var _this = this
   return cachingTransform({
     salt: JSON.stringify({
@@ -94,7 +102,7 @@ NYC.prototype._createTransform = function () {
     factory: this._transformFactory.bind(this),
     cacheDir: this.cacheDirectory,
     disableCache: !this.enableCache,
-    ext: '.js'
+    ext: ext
   })
 }
 
@@ -212,7 +220,15 @@ NYC.prototype._maybeInstrumentSource = function (code, filename, relFile) {
     return null
   }
 
-  return this.transform(code, {filename: filename, relFile: relFile})
+  var ext, transform
+  for (ext in this.transforms) {
+    if (filename.toLowerCase().substr(-ext.length) === ext) {
+      transform = this.transforms[ext]
+      break
+    }
+  }
+
+  return transform ? transform(code, {filename: filename, relFile: relFile}) : null
 }
 
 NYC.prototype._transformFactory = function (cacheDir) {
@@ -238,11 +254,17 @@ NYC.prototype._transformFactory = function (cacheDir) {
   }
 }
 
+NYC.prototype._handleJs = function (code, filename) {
+  var relFile = path.relative(this.cwd, filename)
+  return this._maybeInstrumentSource(code, filename, relFile) || code
+}
+
 NYC.prototype._wrapRequire = function () {
-  var _this = this
-  appendTransform(function (code, filename) {
-    var relFile = path.relative(_this.cwd, filename)
-    return _this._maybeInstrumentSource(code, filename, relFile) || code
+  var handleJs = this._handleJs.bind(this)
+
+  this.extensions.forEach(function (ext) {
+    require.extensions[ext] = js
+    appendTransform(handleJs, ext)
   })
 }
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
       "test/source-map-cache.js",
       "index.covered.js",
       "test/fixtures/_generateCoverage.js"
-    ]
+    ],
+    "extension": [".es6"]
   },
   "standard": {
     "ignore": [
@@ -65,6 +66,7 @@
     "arrify": "^1.0.1",
     "caching-transform": "^1.0.0",
     "convert-source-map": "^1.1.2",
+    "default-require-extensions": "^1.0.0",
     "find-cache-dir": "^0.1.1",
     "foreground-child": "^1.3.5",
     "glob": "^6.0.2",

--- a/test/fixtures/check-instrumented.es6
+++ b/test/fixtures/check-instrumented.es6
@@ -1,0 +1,7 @@
+function probe () {}
+
+// When instrumented there will be references to variables like
+// __cov_pwkoI2PYHp3LJXkn_erl1Q in the probe() source.
+module.exports = function () {
+  return /\b__cov_\B/.test(probe + '')
+}

--- a/test/fixtures/check-instrumented.foo.bar
+++ b/test/fixtures/check-instrumented.foo.bar
@@ -1,0 +1,7 @@
+function probe () {}
+
+// When instrumented there will be references to variables like
+// __cov_pwkoI2PYHp3LJXkn_erl1Q in the probe() source.
+module.exports = function () {
+  return /\b__cov_\B/.test(probe + '')
+}

--- a/test/fixtures/package.json
+++ b/test/fixtures/package.json
@@ -12,7 +12,8 @@
       "exclude": [
         "**/blarg",
         "**/blerg"
-      ]
+      ],
+      "extension": [".es6", ".foo.BAR"]
     }
   }
 }


### PR DESCRIPTION
This adds support for allowing files with extensions other than '.js' to be covered.  It can be configured through package.json config, or command line args.  

As per my comment in issue https://github.com/bcoe/nyc/issues/161#issuecomment-180747165, there aren't any additional tests yet. If you feel some additional tests to cover this functionality would be helpful, I'd appreciate some guidance as to how you think they could be done (I'm not quite used to the way the existing tests are done).  Even just pointing me to existing tests that I could pattern after, would be great.

I'd be glad to address any other comments also.