### PR TITLE
Use absolute file paths in coverage

### DIFF
--- a/lib/source-map-cache.js
+++ b/lib/source-map-cache.js
@@ -5,20 +5,20 @@ function SourceMapCache () {
   this.cache = {}
 }
 
-SourceMapCache.prototype.addMap = function (relFile, map) {
-  this.cache[relFile] = new SourceMapConsumer(map)
+SourceMapCache.prototype.addMap = function (absFile, map) {
+  this.cache[absFile] = new SourceMapConsumer(map)
 }
 
 SourceMapCache.prototype.applySourceMaps = function (report) {
   var _this = this
 
-  Object.keys(report).forEach(function (relFile) {
-    var sourceMap = _this.cache[relFile]
+  Object.keys(report).forEach(function (absFile) {
+    var sourceMap = _this.cache[absFile]
     if (!sourceMap) {
       return
     }
 
-    var fileReport = report[relFile]
+    var fileReport = report[absFile]
     _this._rewritePath(report, fileReport, sourceMap)
     _this._rewriteStatements(fileReport, sourceMap)
     _this._rewriteFunctions(fileReport, sourceMap)
@@ -95,8 +95,7 @@ SourceMapCache.prototype._rewritePath = function (report, fileReport, sourceMap)
   // only rewrite the path if the file comes from a single source
   if (sourceMap.sources.length !== 1) return
 
-  var originalPath = './' + path.join(path.dirname(fileReport.path), sourceMap.sources[0])
-
+  var originalPath = path.resolve(path.dirname(fileReport.path), sourceMap.sources[0])
   report[fileReport.path] = undefined // Hack for Windows tests, until we can normalize paths.
   delete report[fileReport.path]
 

--- a/test/fixtures/_generateReport.js
+++ b/test/fixtures/_generateReport.js
@@ -62,6 +62,7 @@ if (reports.length !== 5) {
 var out = fs.createWriteStream(path.join(__dirname, 'report.js'))
 out.write('// Generated using node test/fixtures/_generateReport.js\n')
 reports.forEach(function (coverage) {
+  coverage.path = path.relative(nyc.cwd, coverage.path)
   out.write('exports[' + JSON.stringify(coverage.path) + '] = ' + JSON.stringify(coverage, null, 2) + '\n')
 })
 out.end()

--- a/test/fixtures/report.js
+++ b/test/fixtures/report.js
@@ -1,6 +1,6 @@
 // Generated using node test/fixtures/_generateReport.js
-exports["./node_modules/source-map-fixtures/fixtures/bundle-inline.js"] = {
-  "path": "./node_modules/source-map-fixtures/fixtures/bundle-inline.js",
+exports["node_modules/source-map-fixtures/fixtures/bundle-inline.js"] = {
+  "path": "node_modules/source-map-fixtures/fixtures/bundle-inline.js",
   "s": {
     "1": 1,
     "2": 1,
@@ -301,8 +301,8 @@ exports["./node_modules/source-map-fixtures/fixtures/bundle-inline.js"] = {
     }
   }
 }
-exports["./node_modules/source-map-fixtures/fixtures/branching-inline.js"] = {
-  "path": "./node_modules/source-map-fixtures/fixtures/branching-inline.js",
+exports["node_modules/source-map-fixtures/fixtures/branching-inline.js"] = {
+  "path": "node_modules/source-map-fixtures/fixtures/branching-inline.js",
   "s": {
     "1": 1,
     "2": 1,
@@ -416,8 +416,8 @@ exports["./node_modules/source-map-fixtures/fixtures/branching-inline.js"] = {
     }
   }
 }
-exports["./node_modules/source-map-fixtures/fixtures/istanbul-ignore-inline.js"] = {
-  "path": "./node_modules/source-map-fixtures/fixtures/istanbul-ignore-inline.js",
+exports["node_modules/source-map-fixtures/fixtures/istanbul-ignore-inline.js"] = {
+  "path": "node_modules/source-map-fixtures/fixtures/istanbul-ignore-inline.js",
   "s": {
     "1": 1,
     "2": 1,
@@ -533,8 +533,8 @@ exports["./node_modules/source-map-fixtures/fixtures/istanbul-ignore-inline.js"]
     }
   }
 }
-exports["./node_modules/source-map-fixtures/fixtures/istanbul-ignore-fn-inline.js"] = {
-  "path": "./node_modules/source-map-fixtures/fixtures/istanbul-ignore-fn-inline.js",
+exports["node_modules/source-map-fixtures/fixtures/istanbul-ignore-fn-inline.js"] = {
+  "path": "node_modules/source-map-fixtures/fixtures/istanbul-ignore-fn-inline.js",
   "s": {
     "1": 1,
     "2": 1,
@@ -676,8 +676,8 @@ exports["./node_modules/source-map-fixtures/fixtures/istanbul-ignore-fn-inline.j
     }
   }
 }
-exports["./node_modules/source-map-fixtures/fixtures/branching-none.js"] = {
-  "path": "./node_modules/source-map-fixtures/fixtures/branching-none.js",
+exports["node_modules/source-map-fixtures/fixtures/branching-none.js"] = {
+  "path": "node_modules/source-map-fixtures/fixtures/branching-none.js",
   "s": {
     "1": 1,
     "2": 1,

--- a/test/src/nyc-test.js
+++ b/test/src/nyc-test.js
@@ -245,7 +245,7 @@ describe('nyc', function () {
 
       proc.on('close', function () {
         var reports = _.filter(nyc._loadReports(), function (report) {
-          return report['./' + signal + '.js']
+          return report[path.join(fixtures, signal + '.js')]
         })
         reports.length.should.equal(1)
         return done()
@@ -296,7 +296,14 @@ describe('nyc', function () {
             add: function (report) {
               // the subprocess we ran should output reports
               // for files in the fixtures directory.
-              Object.keys(report).should.match(/.\/(spawn|child-1|child-2)\.js/)
+              var expected = [
+                'spawn.js',
+                'child-1.js',
+                'child-2.js'
+              ].map(function (relFile) {
+                return path.join(fixtures, relFile)
+              })
+              expected.should.include.members(Object.keys(report))
             }
           },
           {
@@ -489,10 +496,11 @@ describe('nyc', function () {
       nyc.reset()
       nyc.addAllFiles()
 
+      var notLoadedPath = path.join(fixtures, './not-loaded.js')
       var reports = _.filter(nyc._loadReports(), function (report) {
-        return ap(report)['./not-loaded.js']
+        return ap(report)[notLoadedPath]
       })
-      var report = reports[0]['./not-loaded.js']
+      var report = reports[0][notLoadedPath]
 
       reports.length.should.equal(1)
       report.s['1'].should.equal(0)
@@ -510,10 +518,12 @@ describe('nyc', function () {
       require('../fixtures/not-loaded')
 
       nyc.writeCoverageFile()
+
+      var notLoadedPath = path.join(fixtures, './not-loaded.js')
       var reports = _.filter(nyc._loadReports(), function (report) {
-        return report['./not-loaded.js']
+        return report[notLoadedPath]
       })
-      var report = reports[0]['./not-loaded.js']
+      var report = reports[0][notLoadedPath]
 
       reports.length.should.equal(1)
       report.s['1'].should.equal(1)
@@ -530,21 +540,23 @@ describe('nyc', function () {
       )
 
       var nyc = (new NYC({
+        cwd: fixtures,
         require: './test/fixtures/transpile-hook'
       }))
 
       nyc.reset()
       nyc.addAllFiles()
 
+      var needsTranspilePath = path.join(fixtures, './needs-transpile.js')
       var reports = _.filter(nyc._loadReports(), function (report) {
-        return ap(report)['./test/fixtures/needs-transpile.js']
+        return ap(report)[needsTranspilePath]
       })
-      var report = reports[0]['./test/fixtures/needs-transpile.js']
+      var report = reports[0][needsTranspilePath]
 
       reports.length.should.equal(1)
       report.s['1'].should.equal(0)
 
-      fs.unlinkSync('./test/fixtures/needs-transpile.js')
+      fs.unlinkSync(needsTranspilePath)
       return done()
     })
   })


### PR DESCRIPTION
Pass an absolute path to the instrumenter. This results in the coverage containing absolute paths.

Adjust caching and source map logic to use absolute paths. Rename variables.

The change to the source map logic should let it handle source map sources that have absolute paths. Before these were joined to the file path, now the new path is resolved instead.

Fixes #110.
