### PR TITLE
all of nyc's configuration options can now also be set in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ to inline the source map in the transpiled code. For Babel that means setting
 the `sourceMaps` option to `inline`.
 
 ## Support For Custom File Extensions (.jsx, .es6)
+
 Supporting file extensions can be configured through either the configuration arguments or with the `nyc` config section in `package.json`.
 
 ```shell
@@ -148,11 +149,11 @@ As an alternative to providing a list of files to `exclude`, you can provide
 an `include` key to specify specific files that should be covered:
 
 ```json
-{"config": {
+{
   "nyc": {
     "include": ["**/build/umd/moment.js"]
   }
-}}
+}
 ```
 
 > Note: include defaults to `['**']`
@@ -174,6 +175,21 @@ modules should be required in the subprocess collecting coverage:
 You can run `nyc` with the optional `--cache` flag, to prevent it from
 instrumenting the same files multiple times. This can signficantly
 improve runtime performance.
+
+## Configuring nyc
+
+Any configuration options that can be set via the command line
+can also be specified in the `nyc` stanza of your package.json:
+
+```json
+{
+  "nyc": {
+    "lines": 99,
+    "check-coverage": false,
+    "report-dir": "./alternative"
+  },
+}
+```
 
 ## Configuring Istanbul
 

--- a/bin/nyc.js
+++ b/bin/nyc.js
@@ -14,56 +14,25 @@ var wrapper = require.resolve('./wrap.js')
 var yargs = require('yargs')
   .usage('$0 [command] [options]\n\nrun your tests with the nyc bin to instrument them with coverage')
   .command('report', 'run coverage report for .nyc_output', function (yargs) {
-    yargs
+    return yargs
       .usage('$0 report [options]')
-      .option('r', {
-        alias: 'reporter',
-        describe: 'coverage reporter(s) to use',
-        default: 'text'
-      })
-      .option('report-dir', {
-        describe: 'default directory to output coverage reports in',
-        default: 'coverage'
-      })
-      .help('h')
-      .alias('h', 'help')
       .example('$0 report --reporter=lcov', 'output an HTML lcov report to ./coverage')
   })
   .command('check-coverage', 'check whether coverage is within thresholds provided', function (yargs) {
-    yargs
+    return yargs
       .usage('$0 check-coverage [options]')
-      .option('b', {
-        alias: 'branches',
-        default: 0,
-        description: 'what % of branches must be covered?'
-      })
-      .option('f', {
-        alias: 'functions',
-        default: 0,
-        description: 'what % of functions must be covered?'
-      })
-      .option('l', {
-        alias: 'lines',
-        default: 90,
-        description: 'what % of lines must be covered?'
-      })
-      .option('s', {
-        alias: 'statements',
-        default: 0,
-        description: 'what % of statements must be covered?'
-      })
-      .help('h')
-      .alias('h', 'help')
       .example('$0 check-coverage --lines 95', "check whether the JSON in nyc's output folder meets the thresholds provided")
   })
   .option('r', {
     alias: 'reporter',
     describe: 'coverage reporter(s) to use',
-    default: 'text'
+    default: 'text',
+    global: true
   })
   .option('report-dir', {
     describe: 'default directory to output coverage reports in',
-    default: 'coverage'
+    default: 'coverage',
+    global: true
   })
   .option('s', {
     alias: 'silent',
@@ -100,27 +69,33 @@ var yargs = require('yargs')
   })
   .option('branches', {
     default: 0,
-    description: 'what % of branches must be covered?'
+    description: 'what % of branches must be covered?',
+    global: true
   })
   .option('functions', {
     default: 0,
-    description: 'what % of functions must be covered?'
+    description: 'what % of functions must be covered?',
+    global: true
   })
   .option('lines', {
     default: 90,
-    description: 'what % of lines must be covered?'
+    description: 'what % of lines must be covered?',
+    global: true
   })
   .option('statements', {
     default: 0,
-    description: 'what % of statements must be covered?'
+    description: 'what % of statements must be covered?',
+    global: true
   })
   .help('h')
   .alias('h', 'help')
-  .version(require('../package.json').version)
+  .version()
+  .pkgConf('nyc', process.cwd())
   .example('$0 npm test', 'instrument your tests with coverage')
   .example('$0 --require babel-core/polyfill --require babel-core/register npm test', 'instrument your tests with coverage and babel')
   .example('$0 report --reporter=text-lcov', 'output lcov report after running your tests')
   .epilog('visit http://git.io/vTJJB for list of available reporters')
+
 var argv = yargs.argv
 
 if (argv._[0] === 'report') {

--- a/package.json
+++ b/package.json
@@ -34,9 +34,6 @@
       "test/source-map-cache.js",
       "index.covered.js",
       "test/fixtures/_generateCoverage.js"
-    ],
-    "extension": [
-      ".es6"
     ]
   },
   "standard": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
       "index.covered.js",
       "test/fixtures/_generateCoverage.js"
     ],
-    "extension": [".es6"]
+    "extension": [
+      ".es6"
+    ]
   },
   "standard": {
     "ignore": [
@@ -79,18 +81,18 @@
     "micromatch": "~2.1.6",
     "mkdirp": "^0.5.0",
     "pkg-up": "^1.0.0",
-    "read-pkg": "^1.1.0",
     "resolve-from": "^2.0.0",
     "rimraf": "^2.5.0",
     "signal-exit": "^2.1.1",
     "source-map": "^0.5.3",
     "spawn-wrap": "^1.1.1",
     "strip-bom": "^2.0.0",
-    "yargs": "^3.15.0"
+    "yargs": "^4.0.0"
   },
   "devDependencies": {
     "any-path": "^1.3.0",
     "chai": "^3.0.0",
+    "clear-require": "^1.0.1",
     "coveralls": "^2.11.4",
     "exists-sync": "0.0.3",
     "forking-tap": "^0.1.1",

--- a/test/fixtures/package.json
+++ b/test/fixtures/package.json
@@ -7,13 +7,11 @@
     "nyc": "./bin/nyc.js",
     "nyc-report": "./bin/nyc-report.js"
   },
-  "config": {
-    "nyc": {
-      "exclude": [
-        "**/blarg",
-        "**/blerg"
-      ],
-      "extension": [".es6", ".foo.BAR"]
-    }
+  "nyc": {
+    "exclude": [
+      "**/blarg",
+      "**/blerg"
+    ],
+    "extension": [".es6", ".foo.BAR"]
   }
 }

--- a/test/src/nyc-test.js
+++ b/test/src/nyc-test.js
@@ -22,6 +22,7 @@ function NYC (opts) {
 }
 
 var path = require('path')
+var clearRequire = require('clear-require')
 var existsSync = require('exists-sync')
 var rimraf = require('rimraf')
 var sinon = require('sinon')
@@ -532,6 +533,7 @@ describe('nyc', function () {
         'test/nyc-test.js'
       ]
 
+      clearRequire('yargs')
       var yargv = require('yargs').argv
 
       var munged = (new NYC()).mungeArgs(yargv)

--- a/test/src/nyc-test.js
+++ b/test/src/nyc-test.js
@@ -69,7 +69,7 @@ describe('nyc', function () {
   })
 
   describe('config', function () {
-    it("loads 'exclude' patterns from package.json#config.nyc", function () {
+    it("loads 'exclude' patterns from package.json#nyc", function () {
       var nyc = new NYC({
         cwd: path.resolve(__dirname, '../fixtures')
       })
@@ -77,28 +77,12 @@ describe('nyc', function () {
       nyc.exclude.length.should.eql(5)
     })
 
-    it("loads 'exclude' patterns from package.json#nyc", function () {
-      var nyc = new NYC({
-        cwd: path.resolve(__dirname, '../..')
-      })
-
-      nyc.exclude.length.should.eql(19)
-    })
-
-    it("loads 'extension' patterns from package.json#config.nyc", function () {
+    it("loads 'extension' patterns from package.json#nyc", function () {
       var nyc = new NYC({
         cwd: path.resolve(__dirname, '../fixtures')
       })
 
       nyc.extensions.length.should.eql(3)
-    })
-
-    it("loads 'extension' from package.json#nyc", function () {
-      var nyc = new NYC({
-        cwd: path.resolve(__dirname, '../..')
-      })
-
-      nyc.extensions.length.should.eql(2)
     })
   })
 


### PR DESCRIPTION
This will need to be a major bump, because I've retired `config.nyc`.

This upgrades us to `yargs 4.x` which is a pretty major change (so that I can use the new `pkgConf` feature), this is a pretty major change and I would love for folks to take an extra close look to make sure I haven't broken anything.

Note that I could delete a bunch of code with yargs' improved command functionality \o/

Reviewers: @novemberborn, @jamestalmage, @jameswomack, @lloydcotten 

