### PR TITLE
do not infer cwd from pkgUp, if pkgUp walks all the way to /

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ NYC.prototype._loadConfig = function (opts) {
   var cwd = opts.cwd || process.env.NYC_CWD || process.cwd()
   var pkgPath = pkgUp.sync(cwd)
 
-  if (pkgPath) {
+  if (pkgPath && pkgPath !== 'package.json') {
     cwd = path.dirname(pkgPath)
   }
 

--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ NYC.prototype._loadConfig = function (opts) {
   var cwd = opts.cwd || process.env.NYC_CWD || process.cwd()
   var pkgPath = pkgUp.sync(cwd)
 
-  if (pkgPath && pkgPath !== 'package.json') {
+  if (pkgPath) {
     cwd = path.dirname(pkgPath)
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nyc",
-  "version": "5.5.0",
+  "version": "6.0.0",
   "description": "a code coverage tool that works well with subprocesses.",
   "main": "index.js",
   "scripts": {
@@ -71,6 +71,7 @@
     "convert-source-map": "^1.1.2",
     "default-require-extensions": "^1.0.0",
     "find-cache-dir": "^0.1.1",
+    "find-up": "^1.1.2",
     "foreground-child": "^1.3.5",
     "glob": "^6.0.2",
     "istanbul": "^0.4.1",


### PR DESCRIPTION
The library `pkgUp` is used to find the closest package.json, which nyc uses as `cwd`.

If `pkgUp` walks all the way to `/`, it returns the string `package.json`. In this edge-case, we should not switch to `cwd` to the path of the package.json found by `pkgUp`.