### PR TITLE
add more exclude glob patterns

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ function NYC (opts) {
   }
 
   this.exclude = this._prepGlobPatterns(
-    ['**/node_modules/**'].concat(arrify(config.exclude || ['test/**', 'test{,-*}.js']))
+    ['**/node_modules/**'].concat(arrify(config.exclude || ['test/**', 'test{,-*}.js', '*.test.js', '**/__tests__/**']))
   )
 
   this.cacheDirectory = findCacheDir({name: 'nyc', cwd: this.cwd})

--- a/test/src/nyc-test.js
+++ b/test/src/nyc-test.js
@@ -108,7 +108,9 @@ describe('nyc', function () {
       nyc.exclude = nyc._prepGlobPatterns([
         '**/node_modules/**',
         'test/**',
-        'test{,-*}.js'
+        'test{,-*}.js',
+        '*.test.js',
+        '**/__tests__/**'
       ])
 
       var shouldInstrumentFile = nyc.shouldInstrumentFile.bind(nyc)


### PR DESCRIPTION
I personally use (and teach) that applications should co-locate test files and source code, which is where the `*.test.js` comes from.

The React community uses the `__tests__` convention.

Happy to make any changes you'd like to see :-)