### PR TITLE
Update AppVeyor config with ~faster npm install

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,12 +1,11 @@
 environment:
   matrix:
-    - nodejs_version: '5'
-    - nodejs_version: '4'
-    - nodejs_version: '0.12'
+    - nodejs_version: '6' # stable
+    - nodejs_version: '4' # LTS
 install:
   - ps: Install-Product node $env:nodejs_version
   - set CI=true
-  - npm -g install npm@latest
+  - npm config set progress=false
   - set PATH=%APPDATA%\npm;%PATH%
   - npm install
 matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,7 @@ environment:
   matrix:
     - nodejs_version: '6' # stable
     - nodejs_version: '4' # LTS
+    - nodejs_version: '0.12'
 install:
   - ps: Install-Product node $env:nodejs_version
   - set CI=true


### PR DESCRIPTION
Only test against stable and LTS versions of node since AppVeyor goes pretty slow.

@bcoe I noticed that after dropping the Travis build times to 1/4th of what they were on Travis in #251, AppVeyor's build takes even longer... so this is an attempt to streamline it by using the version of `npm` that comes with each node distro and only going for stable and LTS versions. Thoughts?