### PR TITLE
Discard more bad source map positions

### DIFF
--- a/lib/source-map-cache.js
+++ b/lib/source-map-cache.js
@@ -40,6 +40,10 @@ function clampPosition (pos) {
   }
 }
 
+function discardPosition (pos) {
+  return !pos || !pos.source || pos.line === null || pos.column === null
+}
+
 // Maps the coverage location based on the source map. Adapted from getMapping()
 // in remap-istanbul:
 // <https://github.com/SitePen/remap-istanbul/blob/30b67ad3f24ba7e0da8b8888d5a7c3c8480d48b2/lib/remap.js#L55:L108>.
@@ -51,18 +55,7 @@ function mapLocation (sourceMap, location) {
   var end = sourceMap.originalPositionFor(clampedEnd)
 
   /* istanbul ignore if: edge case too hard to test for */
-  if (!start || !end) {
-    return null
-  }
-  if (!start.source || !end.source || start.source !== end.source) {
-    return null
-  }
-  /* istanbul ignore if: edge case too hard to test for */
-  if (start.line === null || start.column === null) {
-    return null
-  }
-  /* istanbul ignore if: edge case too hard to test for */
-  if (end.line === null || end.column === null) {
+  if (discardPosition(start) || discardPosition(end) || start.source !== end.source) {
     return null
   }
 
@@ -72,6 +65,12 @@ function mapLocation (sourceMap, location) {
       column: clampedEnd.column,
       bias: 2
     })
+
+    /* istanbul ignore if: edge case too hard to test for */
+    if (discardPosition(end)) {
+      return null
+    }
+
     end.column = end.column - 1
   }
 


### PR DESCRIPTION
Spotted positions like these in coverage output when debugging #239:

```json
            "1": {
                "start": {
                    "line": 1,
                    "column": 0
                },
                "end": {
                    "line": null,
                    "column": -1
                }
            },
```

This PR adds a guard against badly adjusted end positions, causing those locations to drop out of the report.