### PR TITLE
tests: should read 'lines' from package.json nyc stanza

### DIFF
--- a/test/fixtures/package.json
+++ b/test/fixtures/package.json
@@ -11,6 +11,7 @@
     "exclude": [
       "**/blarg",
       "**/blerg"
-    ]
+    ],
+    "lines": 80
   }
 }

--- a/test/src/nyc-test.js
+++ b/test/src/nyc-test.js
@@ -64,6 +64,14 @@ describe('nyc', function () {
   })
 
   describe('config', function () {
+    it("loads 'lines' number from package.json#nyc", function () {
+      var nyc = new NYC({
+        cwd: path.resolve(__dirname, '../fixtures')
+      })
+
+      nyc.lines.should.eql(80)
+    })
+
     it("loads 'exclude' patterns from package.json#nyc", function () {
       var nyc = new NYC({
         cwd: path.resolve(__dirname, '../fixtures')


### PR DESCRIPTION
I noticed that nyc wasn't loading any of the `check-coverage` arguments from the `package.json` file, but it did work fine for the CLI args - apologies if I'm duplicating here, I did the "PR-with-failing-tests" before checking. 😆 