### PR TITLE
Better ES2015 Support

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,7 @@
 {
-  "presets": ["es2015"]
+  "presets": ["es2015"],
+  "plugins": [
+    "transform-async-to-generator",
+    "transform-runtime"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -89,6 +89,10 @@
   },
   "devDependencies": {
     "any-path": "^1.3.0",
+    "babel-core": "^6.9.1",
+    "babel-plugin-transform-async-to-generator": "^6.8.0",
+    "babel-plugin-transform-runtime": "^6.9.0",
+    "babel-preset-es2015": "^6.9.0",
     "chai": "^3.0.0",
     "coveralls": "^2.11.4",
     "exists-sync": "0.0.3",

--- a/test/fixtures/es2015/asyncawait.js
+++ b/test/fixtures/es2015/asyncawait.js
@@ -1,0 +1,13 @@
+const foo = async (opts, opts2) => {
+  let snuh = await bar()
+}
+
+const bar = () => {
+  return new Promise(function (resolve, reject) {
+    setTimeout(() => {
+      resolve(33)
+    }, 10)
+  })
+}
+
+foo()

--- a/test/fixtures/package.json
+++ b/test/fixtures/package.json
@@ -10,7 +10,8 @@
   "nyc": {
     "exclude": [
       "**/blarg",
-      "**/blerg"
+      "**/blerg",
+      "**/es2015"
     ]
   }
 }

--- a/test/src/es2015.js
+++ b/test/src/es2015.js
@@ -1,0 +1,20 @@
+/* global describe, it */
+
+var NYC
+
+try {
+  NYC = require('../../index.covered.js')
+} catch (e) {
+  NYC = require('../../')
+}
+
+(new NYC()).wrap()
+
+require('babel-core/register')
+require('tap').mochaGlobals()
+
+describe('es2015 coverage', function () {
+  it('covers async/await branch', function () {
+    require('../fixtures/es2015/asyncawait')
+  })
+})

--- a/test/src/nyc-test.js
+++ b/test/src/nyc-test.js
@@ -69,7 +69,7 @@ describe('nyc', function () {
         cwd: path.resolve(__dirname, '../fixtures')
       })
 
-      nyc.exclude.length.should.eql(5)
+      nyc.exclude.length.should.eql(7)
     })
 
     it("loads 'extension' patterns from package.json#nyc", function () {


### PR DESCRIPTION
## The Problem

nyc has several open issues related to ES2015 support:

https://github.com/bcoe/nyc/issues/265
https://github.com/bcoe/nyc/issues/264
https://github.com/bcoe/nyc/issues/215
https://github.com/bcoe/nyc/issues/239
https://github.com/tapjs/node-tap/issues/267

## My Goal

Let's work towards adding better ES2015 support to nyc:

1. using this ticket as a catch-all, and the tests I've checked in as a starting point, let's add regression tests for some of the bad behavior that folks have seen.
2. let's fix the behavior! I think this will require coordination between [Istanbul](https://github.com/gotwarlost/istanbul) and nyc.
  * some of the bad line # mappings might be able to be fixed in our source-map logic (CC: @novemberborn )
  * we might need to address some of the issues in the underlying Istanbul coverage library (CC: @gotwarlost).
  * could we have better native ES2015 support, what does this look like (CC: @JaKXz)
3. let's better document best practices for using nyc with ES2015:
  * I think this should probably be a separate document in a docs folder in nyc. My feeling being that some of the issues folks run into with nyc/ES2015 are actually operator errors.

To get started, I would ask that folks who have run into issues submit pull requests with reproductions to this branch (which will act as a catch all for the time being).

We can build out some failing tests, and hopefully get things to a happier place.

CC: @jmdobry, @skozin, @xjamundx, @remy, @JaKXz