### PR TITLE
feat: add "instrument" option as alternative to specifying noop instrumenter

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ the `sourceMaps` option to `inline`.
         "babel-register"
       ],
       "sourceMap": false,
-      "instrumenter": "./lib/instrumenters/noop"
+      "instrument": false
     }
   }
   ```

--- a/bin/nyc.js
+++ b/bin/nyc.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+var arrify = require('arrify')
 var foreground = require('foreground-child')
 var NYC
 try {
@@ -102,6 +103,11 @@ var yargs = require('yargs/yargs')(process.argv.slice(2))
     type: 'boolean',
     description: 'should nyc detect and handle source maps?'
   })
+  .option('instrument', {
+    default: true,
+    type: 'boolean',
+    description: 'should nyc handle instrumentation?'
+  })
   .option('instrumenter', {
     default: './lib/instrumenters/istanbul',
     type: 'string',
@@ -127,10 +133,14 @@ if (argv._[0] === 'report') {
   checkCoverage(argv)
 } else if (argv._.length) {
   // wrap subprocesses and execute argv[1]
-  if (!Array.isArray(argv.require)) argv.require = [argv.require]
-  if (!Array.isArray(argv.extension)) argv.extension = [argv.extension]
-  if (!Array.isArray(argv.exclude)) argv.exclude = [argv.exclude]
-  if (!Array.isArray(argv.include)) argv.include = [argv.include]
+  argv.require = arrify(argv.require)
+  argv.extension = arrify(argv.extension)
+  argv.exclude = arrify(argv.exclude)
+  argv.include = arrify(argv.include)
+
+  // if instrument is set to false,
+  // enable a noop instrumenter.
+  if (!argv.instrument) argv.instrumenter = './lib/instrumenters/noop'
 
   var nyc = (new NYC({
     require: argv.require,

--- a/test/src/nyc-bin.js
+++ b/test/src/nyc-bin.js
@@ -208,7 +208,6 @@ describe('the nyc cli', function () {
       '--extension=.js',
       '--cache=true',
       '--source-map=true',
-      '--instrumenter=./lib/instrumenters/istanbul.js',
       process.execPath,
       './env.js'
     ]
@@ -219,7 +218,39 @@ describe('the nyc cli', function () {
       NYC_EXTENSION: '.js',
       NYC_CACHE: 'enable',
       NYC_SOURCE_MAP: 'enable',
-      NYC_INSTRUMENTER: './lib/instrumenters/istanbul.js'
+      NYC_INSTRUMENTER: './lib/instrumenters/istanbul'
+    }
+
+    var proc = spawn(process.execPath, args, {
+      cwd: fixturesCLI,
+      env: env
+    })
+
+    var stdout = ''
+    proc.stdout.on('data', function (chunk) {
+      stdout += chunk
+    })
+
+    proc.on('close', function (code) {
+      code.should.equal(0)
+      var env = JSON.parse(stdout)
+      env.should.include(expected)
+      done()
+    })
+  })
+
+  it('setting instrument to "false" sets noop instrumenter', function (done) {
+    var args = [
+      bin,
+      '--silent',
+      '--no-instrument',
+      '--no-source-map',
+      process.execPath,
+      './env.js'
+    ]
+    var expected = {
+      NYC_SOURCE_MAP: 'disable',
+      NYC_INSTRUMENTER: './lib/instrumenters/noop'
     }
 
     var proc = spawn(process.execPath, args, {


### PR DESCRIPTION
it felt a little weird providing a noop instrumenter directly in `__coverage__`, this pull introduces the `instrument` flag instead -- making it possible to setup `__coverage__` with the following config:

```json
 "nyc": {
    "include": [
      "index.js"
    ],
    "require": [
      "babel-register"
    ],
    "reporter": [
      "lcov",
      "text"
    ],
    "sourceMap": false,
    "instrument": false
  }
```

which feels cleaner.