### PR TITLE
docs(env): Add reference to cross-env

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ the `sourceMaps` option to `inline`.
   ```
 
   Note: With this configuration, the `__coverage__` will only be active when `NODE_ENV` or `BABEL_ENV` is `test`.
+  We recommend using the [`cross-env`](https://npmjs.com/package/cross-env) package to set these environment variables
+  in your `package.json` scripts in a way that works cross-platform.
 
 2. disable nyc's instrumentation and source-maps:
 


### PR DESCRIPTION
As discussed in #280